### PR TITLE
feature/internaltransport adds ability to instantiate transport plugins within the emulator

### DIFF
--- a/dtd/nemcontents.dtd
+++ b/dtd/nemcontents.dtd
@@ -1,6 +1,6 @@
 <?xml encoding="UTF-8"?>
 
 <!ENTITY % toplayers "((param+, shim*) | shim+)">
+<!ENTITY % uplayers  "(transport, shim*)">
 <!ENTITY % midlayers "(mac, (shim*, (phy, shim*)?)?) | (phy, shim*)">
-<!ENTITY % botlayers "transport">
-<!ENTITY % alllayers "(%toplayers;)?, (%midlayers;)?, (%botlayers;)?">
+<!ENTITY % alllayers "(%toplayers;)?, (%uplayers;)?, (%midlayers;)?">

--- a/dtd/platform.dtd
+++ b/dtd/platform.dtd
@@ -11,7 +11,8 @@
 <!ATTLIST nem 
           name CDATA #IMPLIED
           id CDATA #REQUIRED
-          definition NMTOKEN #REQUIRED>
+          definition NMTOKEN #REQUIRED
+          transport (external | internal) "internal">
 
 <!ENTITY % param SYSTEM "param.dtd">
 %param;

--- a/include/emane/application/nembuilder.h
+++ b/include/emane/application/nembuilder.h
@@ -134,11 +134,37 @@ namespace EMANE
                      bool bSkipConfigure = false);
 
       /**
+       * Builds a Transport layer
+       *
+       * @param id id of the NEM that will contain the transport
+       * @param sLibraryFile Name of the dll containing the layer
+       * @param request Configuration update request
+       * @param bSkipConfigure Flag indicating whether to skip
+       * calling Component::configure
+       *
+       * @return Unique pointer to an initialized and configured Transport
+       *
+       * @throw Utils::FactoryException when a DLL load error occurs.
+       * @throw InitializeException when an error occurs during
+       * initialization.
+       * @throw ConfigureException when an error occurs during
+       * configure.
+       */
+      std::unique_ptr<NEMLayer>
+      buildTransportLayer(NEMId id,
+                          const std::string & sLibraryFile,
+                          const ConfigurationUpdateRequest & request,
+                          bool bSkipConfigure = false);
+
+
+      /**
        * Builds an NEM
        *
        * @param id NEM id
        * @param layers The NEMLayers comprising the NEM
        * @param request Configuration update request
+       * @param bHasExternalTransport Flag indicating whether transport is
+       * external
        *
        * @return Unique pointer to an initialized NEM
        *
@@ -151,7 +177,8 @@ namespace EMANE
        */
       std::unique_ptr<NEM> buildNEM(NEMId id,
                                     NEMLayers & layers,
-                                    const ConfigurationUpdateRequest & request);
+                                    const ConfigurationUpdateRequest & request,
+                                    bool bHasExternalTransport);
 
       /**
        * Builds an NEM Manager

--- a/include/emane/flowcontrolclient.h
+++ b/include/emane/flowcontrolclient.h
@@ -82,9 +82,9 @@ namespace EMANE
     * Removes a flow control token, blocking until a token is available
     * when flow control is enabled
     *
-    * @return @a true on success
+    * @return Total number of tokens available and a flag indicating success
     */
-    bool removeToken();
+    std::pair<std::uint16_t,bool>  removeToken();
 
    /**
     * Handles a flow control update message

--- a/include/emane/flowcontrolmanager.h
+++ b/include/emane/flowcontrolmanager.h
@@ -74,16 +74,18 @@ namespace EMANE
     /**
      * Removes a flow control token
      *
-     * @return @a true of success
+     * @return Total number of tokens available and a flag indicating success
      */
-    bool removeToken();
+    std::pair<std::uint16_t,bool> removeToken();
 
     /**
      * Add one or more flow control token(s)
      *
      * @param u16Tokens number of tokens
+     *
+     * @return Total number of tokens available and a flag indicating success
      */
-    bool addToken(std::uint16_t u16Tokens = 1);
+    std::pair<std::uint16_t,bool> addToken(std::uint16_t u16Tokens = 1);
 
     /**
      * Handles a flow control update message

--- a/include/emane/transport.h
+++ b/include/emane/transport.h
@@ -34,11 +34,7 @@
 #ifndef EMANETRANSPORT_HEADER_
 #define EMANETRANSPORT_HEADER_
 
-#include "emane/component.h"
-#include "emane/upstreamtransport.h"
-#include "emane/platformserviceuser.h"
-#include "emane/buildable.h"
-#include "emane/runningstatemutable.h"
+#include "emane/nemlayer.h"
 
 #include <string>
 #include <list>
@@ -50,11 +46,7 @@ namespace EMANE
    *
    * @brief Base class for all transports
    */
-  class Transport : public Component,
-                    public UpstreamTransport,
-                    public PlatformServiceUser,
-                    public Buildable,
-                    public RunningStateMutable
+  class Transport : public NEMLayer
   {
   public:
     /**
@@ -70,15 +62,21 @@ namespace EMANE
     NEMId getNEMId() const { return id_; }
     
   protected:
-    Transport(NEMId id, PlatformServiceProvider *pPlatformService):
-      PlatformServiceUser(pPlatformService),
-      id_(id)
-     { }
+    Transport(NEMId id, PlatformServiceProvider * pPlatformService):
+      NEMLayer(id, pPlatformService)
+     {}
 
-    /**
-     * Holds the NEM identifier.
-     */
-    const NEMId id_;
+private:
+    // method meaningless for a Transport layer
+    void processDownstreamPacket(DownstreamPacket &, 
+                                 const ControlMessages &){};
+
+    void processDownstreamControl(const ControlMessages &){};
+    
+    void setUpstreamTransport(UpstreamTransport *){};
+    
+    void sendUpstreamPacket(UpstreamPacket &, 
+                            const ControlMessages &){};
   };
 }
 

--- a/scripts/emanegentransportxml
+++ b/scripts/emanegentransportxml
@@ -99,7 +99,11 @@ try:
         for nem in root.xpath('nem'):
             nemId = int(nem.get('id'))
             nemDefinition = nem.get('definition')
+            nemTransportLocation = nem.get('transport')
 
+            if nemTransportLocation == "internal":
+                continue
+            
             if nemId not in instances:
                 instances[nemId] = {}
 

--- a/src/applications/emane/nemdirector.cc
+++ b/src/applications/emane/nemdirector.cc
@@ -99,10 +99,12 @@ EMANE::Application::NEMDirector::createNEM(EMANE::NEMConfiguration *pNEMConfig)
                                    (*layerIter)->getLibrary(),
                                    (*layerIter)->getConfigurationUpdateRequest()));
             }
-          else 
+           else if ((*layerIter)->getType() == "transport" && !pNEMConfig->isExternalTransport()) 
             {
-              /* Transport layer, do not build, but may be useful to 
-               * configure other subsytems based on transport's config */
+              layers.push_back(rNEMBuilder_.buildTransportLayer(
+                                   pNEMConfig->getNEMId(),
+                                   (*layerIter)->getLibrary(),
+                                   (*layerIter)->getConfigurationUpdateRequest()));
             }
         }// end for layers    
     }// end if valid
@@ -128,5 +130,6 @@ EMANE::Application::NEMDirector::createNEM(EMANE::NEMConfiguration *pNEMConfig)
 
   return rNEMBuilder_.buildNEM(pNEMConfig->getNEMId(), 
                                layers,
-                               pNEMConfig->getConfigurationUpdateRequest());
+                               pNEMConfig->getConfigurationUpdateRequest(),
+                               pNEMConfig->isExternalTransport());
 }

--- a/src/emanesh/emanesh/controlportclient.py
+++ b/src/emanesh/emanesh/controlportclient.py
@@ -182,8 +182,10 @@ class ControlPortClient:
                             name = 'PHY'
                         elif component.type == remotecontrolportapi_pb2.Response.Query.Manifest.NEM.Component.TYPE_COMPONENT_MAC:
                             name = 'MAC'
-                        else:
+                        elif component.type == remotecontrolportapi_pb2.Response.Query.Manifest.NEM.Component.TYPE_COMPONENT_SHIM:
                             name = 'SHIM'
+                        else:
+                            name = 'TRANSPORT'
 
                         layers.append((component.buildId,name,component.plugin))
 

--- a/src/emanesh/emanesh/emaneshell.py
+++ b/src/emanesh/emanesh/emaneshell.py
@@ -531,6 +531,7 @@ class EMANEShell(cmd.Cmd):
             component = args[index].lower()
             if component != 'phy' and \
                     component != 'mac' and \
+                    component != 'transport' and \
                     component != 'all' and \
                     not (re.match('^shim\d+$', component) and component in self._shims):
                 print "error: invalid component layer:",args[index]
@@ -728,6 +729,7 @@ class EMANEShell(cmd.Cmd):
             component = args[index].lower()
             if component != 'phy' and \
                     component != 'mac' and \
+                    component != 'transport' and \
                     component != 'all' and \
                     not (re.match('^shim\d+$', component) and component in self._shims):
                 print "error: invalid component layer:",args[index]
@@ -851,6 +853,7 @@ class EMANEShell(cmd.Cmd):
                             skip = True
                         elif arg == 'phy' or \
                                 arg == 'mac' or \
+                                arg == 'transport' or \
                                 arg == 'all' or \
                                 (re.match('^shim\d+$', arg) and arg in self._shims):
                             layer = arg

--- a/src/libemane/Makefile.am
+++ b/src/libemane/Makefile.am
@@ -159,6 +159,7 @@ libemane_la_SOURCES =                         \
  transportbuilder.cc                          \
  transportfactory.cc                          \
  transportfactorymanager.cc                   \
+ transportlayer.cc                            \
  transportmanagerimpl.cc                      \
  upstreampacket.cc                            \
  upstreamtransport.cc                         \
@@ -279,6 +280,7 @@ EXTRA_DIST=                                   \
  transportfactory.h                           \
  transportfactorymanager.h                    \
  transportmanagerimpl.h                       \
+ transportlayer.h                             \
  tworaypropagationmodelalgorithm.h            \
  wheel.h                                      \
  wheel.inl                                    \

--- a/src/libemane/Makefile.in
+++ b/src/libemane/Makefile.in
@@ -220,6 +220,7 @@ am_libemane_la_OBJECTS = libemane_la-antennapattern.lo \
 	libemane_la-transportbuilder.lo \
 	libemane_la-transportfactory.lo \
 	libemane_la-transportfactorymanager.lo \
+	libemane_la-transportlayer.lo \
 	libemane_la-transportmanagerimpl.lo \
 	libemane_la-upstreampacket.lo libemane_la-upstreamtransport.lo \
 	libemane_la-velocityformatter.lo \
@@ -609,6 +610,7 @@ libemane_la_SOURCES = \
  transportbuilder.cc                          \
  transportfactory.cc                          \
  transportfactorymanager.cc                   \
+ transportlayer.cc                            \
  transportmanagerimpl.cc                      \
  upstreampacket.cc                            \
  upstreamtransport.cc                         \
@@ -727,6 +729,7 @@ EXTRA_DIST = \
  transportfactory.h                           \
  transportfactorymanager.h                    \
  transportmanagerimpl.h                       \
+ transportlayer.h                             \
  tworaypropagationmodelalgorithm.h            \
  wheel.h                                      \
  wheel.inl                                    \
@@ -967,6 +970,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/libemane_la-transportbuilder.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/libemane_la-transportfactory.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/libemane_la-transportfactorymanager.Plo@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/libemane_la-transportlayer.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/libemane_la-transportmanagerimpl.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/libemane_la-upstreampacket.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/libemane_la-upstreamtransport.Plo@am__quote@
@@ -1818,6 +1822,13 @@ libemane_la-transportfactorymanager.lo: transportfactorymanager.cc
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='transportfactorymanager.cc' object='libemane_la-transportfactorymanager.lo' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libemane_la_CPPFLAGS) $(CPPFLAGS) $(libemane_la_CXXFLAGS) $(CXXFLAGS) -c -o libemane_la-transportfactorymanager.lo `test -f 'transportfactorymanager.cc' || echo '$(srcdir)/'`transportfactorymanager.cc
+
+libemane_la-transportlayer.lo: transportlayer.cc
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libemane_la_CPPFLAGS) $(CPPFLAGS) $(libemane_la_CXXFLAGS) $(CXXFLAGS) -MT libemane_la-transportlayer.lo -MD -MP -MF $(DEPDIR)/libemane_la-transportlayer.Tpo -c -o libemane_la-transportlayer.lo `test -f 'transportlayer.cc' || echo '$(srcdir)/'`transportlayer.cc
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) $(DEPDIR)/libemane_la-transportlayer.Tpo $(DEPDIR)/libemane_la-transportlayer.Plo
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='transportlayer.cc' object='libemane_la-transportlayer.lo' libtool=yes @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libemane_la_CPPFLAGS) $(CPPFLAGS) $(libemane_la_CXXFLAGS) $(CXXFLAGS) -c -o libemane_la-transportlayer.lo `test -f 'transportlayer.cc' || echo '$(srcdir)/'`transportlayer.cc
 
 libemane_la-transportmanagerimpl.lo: transportmanagerimpl.cc
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libemane_la_CPPFLAGS) $(CPPFLAGS) $(libemane_la_CXXFLAGS) $(CXXFLAGS) -MT libemane_la-transportmanagerimpl.lo -MD -MP -MF $(DEPDIR)/libemane_la-transportmanagerimpl.Tpo -c -o libemane_la-transportmanagerimpl.lo `test -f 'transportmanagerimpl.cc' || echo '$(srcdir)/'`transportmanagerimpl.cc

--- a/src/libemane/configurationservice.cc
+++ b/src/libemane/configurationservice.cc
@@ -402,7 +402,21 @@ EMANE::ConfigurationService::buildUpdates(BuildId buildId,
                });
 
     }
-
+  else
+    {
+      if(!parameters.empty())
+        {
+          std::string sUnexpected{};
+          
+          for(const auto & parameter : parameters)
+            {
+              sUnexpected.append(parameter.first + " ");
+            }
+          
+          throw makeException<ConfigurationException>("Parameter(s) not registered: %s",
+                                                      sUnexpected.c_str());
+        }
+    }
   return updates;
 }
 

--- a/src/libemane/flowcontrolclient.cc
+++ b/src/libemane/flowcontrolclient.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013 - Adjacent Link LLC, Bridgewater, New Jersey
+ * Copyright (c) 2013-2014 - Adjacent Link LLC, Bridgewater, New Jersey
  * Copyright (c) 2010 - DRS CenGen, LLC, Columbia, Maryland
  * All rights reserved.
  *
@@ -69,7 +69,7 @@ public:
     mutex_.release();
   }
 
-  bool removeToken()
+  std::pair<std::uint16_t,bool> removeToken()
   {
     ACE_Guard<ACE_Thread_Mutex> m(mutex_);
     
@@ -97,7 +97,7 @@ public:
         --u16TokensAvailable_;
       }
     
-    return bStatus;
+    return {u16TokensAvailable_,bStatus};
   }
 
   void processFlowControlMessage(const Controls::FlowControlControlMessage * pMessage)
@@ -147,7 +147,7 @@ void EMANE::FlowControlClient::stop()
 
 
 
-bool EMANE::FlowControlClient::removeToken()
+std::pair<std::uint16_t,bool> EMANE::FlowControlClient::removeToken()
 {
   return pImpl_->removeToken();
 }

--- a/src/libemane/manifestqueryhandler.cc
+++ b/src/libemane/manifestqueryhandler.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013 - Adjacent Link LLC, Bridgewater, New Jersey
+ * Copyright (c) 2013-2014 - Adjacent Link LLC, Bridgewater, New Jersey
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -71,7 +71,9 @@ EMANE::ControlPort::ManifestQueryHandler::process(std::uint32_t u32Sequence,
                                Component::TYPE_COMPONENT_PHY : 
                                componentType == ComponentType::COMPONENT_MACILAYER ?
                                Component::TYPE_COMPONENT_MAC : 
-                               Component::TYPE_COMPONENT_SHIM);
+                               componentType == ComponentType::COMPONENT_SHIMILAYER ?
+                               Component::TYPE_COMPONENT_SHIM:
+                               Component::TYPE_COMPONENT_TRANSPORT);
 
           pComponent->set_plugin(std::get<2>(component));
         }

--- a/src/libemane/nemimpl.h
+++ b/src/libemane/nemimpl.h
@@ -65,7 +65,8 @@ namespace EMANE
        *
        */
       NEMImpl(NEMId id, 
-              std::unique_ptr<NEMLayerStack> & pNEMLayerStack);
+              std::unique_ptr<NEMLayerStack> & pNEMLayerStack,
+              bool bExternalTransport);
     
       ~NEMImpl();
 
@@ -92,7 +93,8 @@ namespace EMANE
     private:
       std::unique_ptr<NEMLayerStack> pNEMLayerStack_;
       NEMId id_;
-    
+      bool bExternalTransport_;
+      
       NEMOTAAdapter     NEMOTAAdapter_;
       NEMNetworkAdapter NEMNetworkAdapter_;
 

--- a/src/libemane/remotecontrolportapi.proto
+++ b/src/libemane/remotecontrolportapi.proto
@@ -267,6 +267,7 @@ message Response
             TYPE_COMPONENT_MAC = 1;
             TYPE_COMPONENT_PHY = 2;
             TYPE_COMPONENT_SHIM = 3;
+            TYPE_COMPONENT_TRANSPORT = 4;
           }
           // component build id
           required uint32 buildId = 1;

--- a/src/libemane/transportlayer.cc
+++ b/src/libemane/transportlayer.cc
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2014 - Adjacent Link LLC, Bridgewater, New Jersey
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in
+ *   the documentation and/or other materials provided with the
+ *   distribution.
+ * * Neither the name of Adjacent Link LLC nor the names of its
+ *   contributors may be used to endorse or promote products derived
+ *   from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "transportlayer.h"
+
+EMANE::TransportLayer::TransportLayer(NEMId id,
+                                      Transport * pImplementor,
+                                      PlatformServiceProvider * pPlatformService) :
+  NEMQueuedLayer{id, pPlatformService},
+  pImplementor_{pImplementor},
+  pPlatformService_{pPlatformService}
+{}
+
+EMANE::TransportLayer::~TransportLayer()
+{}
+
+void EMANE::TransportLayer::initialize(Registrar & registrar)
+{
+  NEMQueuedLayer::initialize(registrar);
+  
+  pImplementor_->initialize(registrar);
+}
+
+
+void EMANE::TransportLayer::configure(const ConfigurationUpdate & update)
+{
+  pImplementor_->configure(update);
+}
+
+
+void EMANE::TransportLayer::start()
+{
+  // start the queue processing thread
+  NEMQueuedLayer::start();
+
+  pImplementor_->start();
+}
+
+
+void EMANE::TransportLayer::postStart()
+{
+  pImplementor_->postStart();
+}
+
+
+void EMANE::TransportLayer::stop()
+{
+  pImplementor_->stop();
+
+  // stop the queue processing thread
+  NEMQueuedLayer::stop();
+}
+
+
+void EMANE::TransportLayer::destroy() throw()
+{
+  pImplementor_->destroy();
+}
+
+void EMANE::TransportLayer::setDownstreamTransport(DownstreamTransport * pDownstreamTransport)
+{
+  pImplementor_->setDownstreamTransport(pDownstreamTransport);
+}
+
+void EMANE::TransportLayer::doProcessConfiguration(const ConfigurationUpdate & update)
+{
+  pImplementor_->processConfiguration(update);
+}
+
+void EMANE::TransportLayer::doProcessUpstreamPacket(UpstreamPacket & pkt,
+                                              const ControlMessages & ctrl)
+{
+  static_cast<UpstreamTransport *>(pImplementor_.get())->processUpstreamPacket(pkt,ctrl);
+}
+
+
+void EMANE::TransportLayer::doProcessUpstreamControl(const ControlMessages & msgs)
+{
+  pImplementor_->processUpstreamControl(msgs);
+}
+
+
+void EMANE::TransportLayer::doProcessEvent(const EventId & eventId,
+                                     const Serialization & serialization)
+{
+  pImplementor_->processEvent(eventId,serialization);
+}
+
+
+void EMANE::TransportLayer::doProcessTimedEvent(TimerEventId eventId,
+                                          const TimePoint & expireTime,
+                                          const TimePoint & scheduleTime,
+                                          const TimePoint & fireTime,
+                                          const void * arg)
+{
+  pImplementor_->processTimedEvent(eventId,expireTime,scheduleTime,fireTime,arg);
+}
+
+// method meaningless for a Transport layer
+void EMANE::TransportLayer::setUpstreamTransport(UpstreamTransport *)
+{}
+
+void EMANE::TransportLayer::doProcessDownstreamPacket(DownstreamPacket &,
+                                                      const ControlMessages &)
+{}
+
+
+void EMANE::TransportLayer::doProcessDownstreamControl(const ControlMessages &)
+{}

--- a/src/libemane/transportlayer.h
+++ b/src/libemane/transportlayer.h
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2014 - Adjacent Link LLC, Bridgewater, New Jersey
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in
+ *   the documentation and/or other materials provided with the
+ *   distribution.
+ * * Neither the name of Adjacent Link LLC nor the names of its
+ *   contributors may be used to endorse or promote products derived
+ *   from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef EMANETRANSPORTLAYER_HEADER_
+#define EMANETRANSPORTLAYER_HEADER_
+
+#include "nemqueuedlayer.h"
+#include "emane/transport.h"
+
+#include <memory>
+
+namespace EMANE
+{
+  /**
+   * @class TransportLayer
+   *
+   * @brief Bridge for the Transport NEM layer.  Decouples a TransportLayerImplementor
+   * implementation from the NEM to allow for interface modification
+   * and encapsulation.
+   */
+  class TransportLayer : public NEMQueuedLayer
+  {
+  public:
+    TransportLayer(NEMId id,
+                   Transport * pImplementor,
+                   PlatformServiceProvider * pPlatformService);
+    
+    ~TransportLayer();
+    
+    void initialize(Registrar & registrar) override;
+    
+    void configure(const ConfigurationUpdate & update) override;
+
+    void start() override;
+
+    void postStart() override;
+
+    void stop() override;
+    
+    void destroy() throw() override;
+
+    void setUpstreamTransport(UpstreamTransport *) override;
+
+    void setDownstreamTransport(DownstreamTransport *) override;
+
+  private:
+    std::unique_ptr<Transport> pImplementor_;
+
+    std::unique_ptr<PlatformServiceProvider> pPlatformService_;
+
+    void doProcessConfiguration(const ConfigurationUpdate &) override;
+
+    void doProcessDownstreamControl(const ControlMessages &) override;
+    
+    void doProcessDownstreamPacket(DownstreamPacket &,const ControlMessages &) override;
+
+    void doProcessUpstreamPacket(UpstreamPacket &,const ControlMessages &) override;
+
+    void doProcessUpstreamControl(const ControlMessages &) override;
+
+    void doProcessEvent(const EventId &, const Serialization &) override;
+
+    void doProcessTimedEvent(TimerEventId eventId,
+                             const TimePoint & expireTime,
+                             const TimePoint & scheduleTime,
+                             const TimePoint & fireTime,
+                             const void * arg) override;
+  };
+}
+
+#endif //EMANETRANSPORTLAYER_HEADER_

--- a/src/libemanexmlparser/nemconfiguration.cc
+++ b/src/libemanexmlparser/nemconfiguration.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013 - Adjacent Link LLC, Bridgewater, New Jersey
+ * Copyright (c) 2013-2014 - Adjacent Link LLC, Bridgewater, New Jersey
  * Copyright (c) 2009-2010 - DRS CenGen, LLC, Columbia, Maryland
  * All rights reserved.
  *
@@ -49,6 +49,8 @@ EMANE::NEMConfiguration::NEMConfiguration(xmlNodePtr pNEMNode,
 
   u16Id_ = getAttrValNumeric(pNEMNode, "id");
 
+  bExternalTransport_ = getAttrVal(pNEMNode, "transport") == "external" ? true : false;
+
   // overlay these param values on previously parsed
   overlayParams(pNEMNode);
 }
@@ -73,6 +75,13 @@ const EMANE::LayerConfigurations
 &EMANE::NEMConfiguration::getLayers()
 {
   return layers_;
+}
+
+
+bool
+EMANE::NEMConfiguration::isExternalTransport()
+{
+  return bExternalTransport_;
 }
 
 

--- a/src/libemanexmlparser/nemconfiguration.h
+++ b/src/libemanexmlparser/nemconfiguration.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013 - Adjacent Link LLC, Bridgewater, New Jersey
+ * Copyright (c) 2013-2014 - Adjacent Link LLC, Bridgewater, New Jersey
  * Copyright (c) 2009-2010 - DRS CenGen, LLC, Columbia, Maryland
  * All rights reserved.
  *
@@ -100,6 +100,14 @@ namespace EMANE
      */
     bool isValid();
 
+
+    /**
+     * Returns whether-or-not this NEM transport is external
+     *
+     * @return True if external, false otherwise
+     */
+    bool isExternalTransport();
+
   protected:
     /**
      * Does processing of the root node as if it was an 'nem'
@@ -134,6 +142,11 @@ namespace EMANE
      * NEM type
      */
     NEMType type_;
+
+    /**
+     * Transport external flag
+     */
+    bool bExternalTransport_;
 
     /**
      * Process a layer element

--- a/src/models/mac/ieee80211abg/maclayer.cc
+++ b/src/models/mac/ieee80211abg/maclayer.cc
@@ -1966,14 +1966,17 @@ EMANE::Models::IEEE80211ABG::MACLayer::addToken()
 {
   if(macConfig_.getFlowControlEnable())
     {
-      if(!flowControlManager_.addToken())
+      auto status = flowControlManager_.addToken();
+      
+      if(!status.second)
         {
           LOGGER_STANDARD_LOGGING(pPlatformService_->logService(),
                                   ERROR_LEVEL,
-                                  "MACI %03hu %s::%s: failed to add token",
+                                  "MACI %03hu %s::%s: failed to add token (tokens:%hu)",
                                   id_,
                                   pzLayerName,
-                                  __func__);
+                                  __func__,
+                                  status.first);
           
           // failed
           return false;
@@ -1991,14 +1994,17 @@ EMANE::Models::IEEE80211ABG::MACLayer::removeToken()
 {
   if(macConfig_.getFlowControlEnable())
     {
-      if(!flowControlManager_.removeToken())
+      auto status = flowControlManager_.removeToken();
+      
+      if(!status.second)
         {
           LOGGER_STANDARD_LOGGING(pPlatformService_->logService(),
                                   ERROR_LEVEL,
-                                  "MACI %03hu %s::%s: failed to remove token",
+                                  "MACI %03hu %s::%s: failed to remove token (tokens:%hu)",
                                   id_,
                                   pzLayerName,
-                                  __func__);
+                                  __func__,
+                                  status.first);
 
 
           // failed

--- a/src/transports/virtual/virtualtransport.cc
+++ b/src/transports/virtual/virtualtransport.cc
@@ -482,7 +482,7 @@ void EMANE::Transports::Virtual::VirtualTransport::handleUpstreamControl(const C
               if(bFlowControlEnable_)
                 {
                   LOGGER_VERBOSE_LOGGING(pPlatformService_->logService(),
-                                                 ERROR_LEVEL,
+                                                 DEBUG_LEVEL,
                                                  "TRANSPORTI %03hu VirtualTransport::%s received a flow control"
                                                  " token update %hu tokens",
                                                  id_,
@@ -502,6 +502,51 @@ void EMANE::Transports::Virtual::VirtualTransport::handleUpstreamControl(const C
                 }
             }
           break;
+
+        case Controls::R2RINeighborMetricControlMessage::IDENTIFIER:
+          {
+             const auto pR2RINeighborMetricControlMessage =
+                static_cast<const Controls::R2RINeighborMetricControlMessage *>(pMessage);
+             
+
+            LOGGER_VERBOSE_LOGGING_FN_VARGS(pPlatformService_->logService(),
+                                            DEBUG_LEVEL, 
+                                            Controls::R2RINeighborMetricControlMessageFormatter(pR2RINeighborMetricControlMessage),
+                                            "TRANSPORTI %03hu VirtualTransport::%s R2RINeighborMetricControlMessage",
+                                            id_, 
+                                            __func__);
+          }
+          break;
+
+        case Controls::R2RIQueueMetricControlMessage::IDENTIFIER:
+          {
+            const auto pR2RIQueueMetricControlMessage =
+              static_cast<const Controls::R2RIQueueMetricControlMessage *>(pMessage);
+            
+            LOGGER_VERBOSE_LOGGING_FN_VARGS(pPlatformService_->logService(),
+                                            DEBUG_LEVEL, 
+                                            Controls::R2RIQueueMetricControlMessageFormatter(pR2RIQueueMetricControlMessage),
+                                            "TRANSPORTI %03hu VirtualTransport::%s R2RIQueueMetricControlMessage",
+                                            id_, 
+                                            __func__);
+          }
+          break;
+
+        case Controls::R2RISelfMetricControlMessage::IDENTIFIER:
+          {
+            const auto pR2RISelfMetricControlMessage =
+              static_cast<const Controls::R2RISelfMetricControlMessage *>(pMessage);
+              
+            LOGGER_VERBOSE_LOGGING_FN_VARGS(pPlatformService_->logService(),
+                                            DEBUG_LEVEL, 
+                                            Controls::R2RISelfMetricControlMessageFormatter(pR2RISelfMetricControlMessage),
+                                            "TRANSPORTI %03hu VirtualTransport::%s R2RISelfMetricControlMessage",
+                                            id_, 
+                                            __func__);
+          }
+          break;
+
+
 
           case Controls::SerializedControlMessage::IDENTIFIER:
             {
@@ -696,14 +741,17 @@ ACE_THR_FUNC_RETURN EMANE::Transports::Virtual::VirtualTransport::readDevice()
                   // check flow control 
                   if(bFlowControlEnable_)
                     {
+                      auto status = flowControlClient_.removeToken();
+                      
                       // block and wait for an available flow control token
-                      if(!flowControlClient_.removeToken())
+                      if(!status.second)
                         {
                           LOGGER_VERBOSE_LOGGING(pPlatformService_->logService(),
                                                  ERROR_LEVEL,
-                                                 "TRANSPORTI %03hu VirtualTransport::%s failed to remove token", 
+                                                 "TRANSPORTI %03hu VirtualTransport::%s failed to remove token (tokens:%hu)", 
                                                  id_, 
-                                                 __func__);
+                                                 __func__,
+                                                 status.first);
                           // done
                           break;
                         }
@@ -711,9 +759,10 @@ ACE_THR_FUNC_RETURN EMANE::Transports::Virtual::VirtualTransport::readDevice()
                         {
                           LOGGER_VERBOSE_LOGGING(pPlatformService_->logService(),
                                                  DEBUG_LEVEL, 
-                                                 "TRANSPORTI %03hu VirtualTransport::%s removed token", 
+                                                 "TRANSPORTI %03hu VirtualTransport::%s removed token (tokens:%hu)", 
                                                  id_,
-                                                 __func__);
+                                                 __func__,
+                                                 status.first);
                         }
                     }
  


### PR DESCRIPTION
Added the ability to instantiate transport plugins within the emulator
(internal transports) as an NEM layer stack entry. This eliminates the
need for running emanetransportd in all use cases where emane and
emanetransportd are running on the same node.

Transports that are internal to the NEM no longer require
platformendpoint and transportendpoint configuration parameters. In
order to connect an emulator with an external transport, either running
in emanetransportd or embedded in another application, you will have to
add a transport='external' attribute to the <nem> platform XML elements
and specify both platformendpoint and transportendpoint. Internal
transports are now the default.

In order to support internal transports, DTDs were changed to remove the
often confusing <transport> is not in the proper place when defining an
NEM. Existing XML will have to place <transport> at the top of layer
definitions instead of the bottom, this is where it logically belongs.

The Remote Control Port protobuf specification and emanesh were modified
to support configuration, statistic and statistic table access for
internal transports.

emanegentransportxml was modified to ignore internal transports.

Fixed flow control token grant acknowledgment bug. See
https://github.com/adjacentlink/emane/issues/8.
