### PR TITLE
feature/virtualtransportunknownprotocolmapping

### DIFF
--- a/src/transports/common/ethernettransport.cc
+++ b/src/transports/common/ethernettransport.cc
@@ -267,8 +267,21 @@ int EMANE::Transports::Ethernet::EthernetTransport::parseFrame(const Utils::Ethe
                               __func__, 
                               u16ethProtocol);
 
-       // use broadcast mac addr
-       rNemDestination = NEM_BROADCAST_MAC_ADDRESS;
+       // broadcast always mode
+       if(bBroadcastMode_)
+         {
+           rNemDestination = NEM_BROADCAST_MAC_ADDRESS;
+         }
+       // check arp cache
+       else if (bArpCacheMode_)
+         {
+           rNemDestination = lookupArpCache(&pEthHeader->dst);
+         }
+       // use the last 2 bytes of the ethernet destination
+       else
+         {
+           rNemDestination = ACE_NTOHS(pEthHeader->dst.words.word3);
+         }
 
        // set dscp to 0
        rDspc = 0;


### PR DESCRIPTION
Modified logic for determining destination nem from mac address when handling an unknown ethernet protocol. Previous logic always assigned NEM_BROADCAST_MAC_ADDRESS. Modified logic performs broadcast only and arp cache mode checks prior to using the last 2 bytes of the mac
address as the nem id.

Reported-by: Adrian Granados
See https://github.com/adjacentlink/emane/issues/19