### PR TITLE
Incorrect min value for the noisemaxclampenable FrameworkPHY

### DIFF
--- a/src/libemane/frameworkphy.cc
+++ b/src/libemane/frameworkphy.cc
@@ -177,8 +177,7 @@ void EMANE::FrameworkPHY::initialize(Registrar & registrar)
                                         " propagation associated with a received packet will be clamped"
                                         " to their respective maximums defined by noisemaxsegmentoffset,"
                                         " noisemaxsegmentduration and noisemaxmessagepropagation. When"
-                                        " disabled, any packet with an above max value will be dropped.",
-                                        1);
+                                        " disabled, any packet with an above max value will be dropped.");
 
 
   configRegistrar.registerNumeric<std::uint64_t>("noisemaxsegmentoffset",


### PR DESCRIPTION
The bool configuration parameter is registered with a minimum value of 1 (true). This prevents configuring the parameter to false.

Developed-by: Tom Goff <https://github.com/tomgoff>

See https://github.com/adjacentlink/emane/issues/26