### PR TITLE
Sample NEM configuration and RPM packaging fixes

### DIFF
--- a/configure
+++ b/configure
@@ -16871,7 +16871,7 @@ $as_echo "#define __BIG_ENDIAN 4321" >>confdefs.h
 
 
 # compiler options
-CXXFLAGS="$CXXFLAGS -W -Wall -g0 -O3"
+CXXFLAGS="$CXXFLAGS -W -Wall -O3"
 
 # options for use with gprof
 if test "$with_profile" = "yes"

--- a/configure.ac
+++ b/configure.ac
@@ -163,7 +163,7 @@ AC_DEFINE([__LITTLE_ENDIAN],1234,[for the places where it is not defined])
 AC_DEFINE([__BIG_ENDIAN],4321,[for the places where it is not defined])
 
 # compiler options
-CXXFLAGS="$CXXFLAGS -W -Wall -g0 -O3"
+CXXFLAGS="$CXXFLAGS -W -Wall -O3"
 
 # options for use with gprof
 if test "$with_profile" = "yes"

--- a/emane.spec.in
+++ b/emane.spec.in
@@ -155,7 +155,7 @@ Group: Libraries
 EMANE Timing Test shim
 
 %package gen-eel
-Requires: emane = %{version}
+Requires: emane-eventservice = %{version}
 Summary: EMANE Emulation Event Log Generator
 Group: Libraries
 

--- a/emane.spec.in
+++ b/emane.spec.in
@@ -183,7 +183,11 @@ make DESTDIR=${RPM_BUILD_ROOT} install
 find ${RPM_BUILD_ROOT} -name '*.a' -exec rm '{}'  \;
 find ${RPM_BUILD_ROOT} -name '*.la' -exec rm '{}' \;
 mkdir -p ${RPM_BUILD_ROOT}%{_pkgdocdir}
-install -t ${RPM_BUILD_ROOT}%{_pkgdocdir} AUTHORS COPYING ChangeLog NEWS README PROBLEM-REPORT-FORM SPONSOR
+install -t ${RPM_BUILD_ROOT}%{_pkgdocdir} AUTHORS %{!?_licensedir:COPYING} ChangeLog NEWS README PROBLEM-REPORT-FORM SPONSOR
+%if 0%{?_licensedir:1}
+mkdir -p ${RPM_BUILD_ROOT}%{_licensedir}/%{name}
+install -t ${RPM_BUILD_ROOT}%{_licensedir}/%{name} COPYING
+%endif
 
 %clean
 rm -rf $RPM_BUILD_ROOT
@@ -201,6 +205,10 @@ rm -rf $RPM_BUILD_ROOT
 %{_mandir}/man1/emane.1.gz
 
 %doc %{_pkgdocdir}
+%if 0%{?_licensedir:1}
+%dir %{_licensedir}/%{name}
+%license %{_licensedir}/%{name}/COPYING
+%endif
 
 %files utils
 %defattr(-, root, root)
@@ -209,6 +217,10 @@ rm -rf $RPM_BUILD_ROOT
 %{_mandir}/man1/emanegentransportxml.1.gz
 
 %doc %{_pkgdocdir}
+%if 0%{?_licensedir:1}
+%dir %{_licensedir}/%{name}
+%license %{_licensedir}/%{name}/COPYING
+%endif
 
 %files dtds
 %defattr(-, root, root)
@@ -234,6 +246,10 @@ rm -rf $RPM_BUILD_ROOT
 %{_datadir}/emane/schema/tdmabasemodelpcr.xsd
 
 %doc %{_pkgdocdir}
+%if 0%{?_licensedir:1}
+%dir %{_licensedir}/%{name}
+%license %{_licensedir}/%{name}/COPYING
+%endif
 
 %files libs
 %defattr(-, root, root)
@@ -241,6 +257,10 @@ rm -rf $RPM_BUILD_ROOT
 %{_libdir}/libemane.*
 
 %doc %{_pkgdocdir}
+%if 0%{?_licensedir:1}
+%dir %{_licensedir}/%{name}
+%license %{_licensedir}/%{name}/COPYING
+%endif
 
 %files transportdaemon
 %defattr(-, root, root)
@@ -248,6 +268,10 @@ rm -rf $RPM_BUILD_ROOT
 %{_mandir}/man1/emanetransportd.1.gz
 
 %doc %{_pkgdocdir}
+%if 0%{?_licensedir:1}
+%dir %{_licensedir}/%{name}
+%license %{_licensedir}/%{name}/COPYING
+%endif
 
 %files eventdaemon
 %defattr(-, root, root)
@@ -255,6 +279,10 @@ rm -rf $RPM_BUILD_ROOT
 %{_mandir}/man1/emaneeventd.1.gz
 
 %doc %{_pkgdocdir}
+%if 0%{?_licensedir:1}
+%dir %{_licensedir}/%{name}
+%license %{_licensedir}/%{name}/COPYING
+%endif
 
 %files eventservice
 %defattr(-, root, root)
@@ -262,6 +290,10 @@ rm -rf $RPM_BUILD_ROOT
 %{_mandir}/man1/emaneeventservice.1.gz
 
 %doc %{_pkgdocdir}
+%if 0%{?_licensedir:1}
+%dir %{_licensedir}/%{name}
+%license %{_licensedir}/%{name}/COPYING
+%endif
 
 %files devel
 %defattr(-, root, root)
@@ -269,6 +301,10 @@ rm -rf $RPM_BUILD_ROOT
 %{_libdir}/pkgconfig/*
 
 %doc %{_pkgdocdir}
+%if 0%{?_licensedir:1}
+%dir %{_licensedir}/%{name}
+%license %{_licensedir}/%{name}/COPYING
+%endif
 
 %files model-rfpipe
 %defattr(-, root, root)
@@ -278,6 +314,10 @@ rm -rf $RPM_BUILD_ROOT
 %{_datadir}/emane/xml/models/mac/rfpipe/rfpipepcr.xml
 
 %doc %{_pkgdocdir}
+%if 0%{?_licensedir:1}
+%dir %{_licensedir}/%{name}
+%license %{_licensedir}/%{name}/COPYING
+%endif
 
 %files model-bypass
 %defattr(-, root, root)
@@ -288,6 +328,10 @@ rm -rf $RPM_BUILD_ROOT
 %{_datadir}/emane/xml/models/mac/bypass/bypassnem.xml
 
 %doc %{_pkgdocdir}
+%if 0%{?_licensedir:1}
+%dir %{_licensedir}/%{name}
+%license %{_licensedir}/%{name}/COPYING
+%endif
 
 %files model-ieee80211abg
 %defattr(-, root, root)
@@ -297,6 +341,10 @@ rm -rf $RPM_BUILD_ROOT
 %{_datadir}/emane/xml/models/mac/ieee80211abg/ieee80211pcr.xml
 
 %doc %{_pkgdocdir}
+%if 0%{?_licensedir:1}
+%dir %{_licensedir}/%{name}
+%license %{_licensedir}/%{name}/COPYING
+%endif
 
 %files agent-gpsdlocation
 %defattr(-, root, root)
@@ -304,6 +352,10 @@ rm -rf $RPM_BUILD_ROOT
 %{_datadir}/emane/xml/agents/gpsdlocation/gpsdlocationagent.xml
 
 %doc %{_pkgdocdir}
+%if 0%{?_licensedir:1}
+%dir %{_licensedir}/%{name}
+%license %{_licensedir}/%{name}/COPYING
+%endif
 
 %files trans-virtual
 %defattr(-, root, root)
@@ -311,6 +363,10 @@ rm -rf $RPM_BUILD_ROOT
 %{_datadir}/emane/xml/transports/virtual/transvirtual.xml
 
 %doc %{_pkgdocdir}
+%if 0%{?_licensedir:1}
+%dir %{_licensedir}/%{name}
+%license %{_licensedir}/%{name}/COPYING
+%endif
 
 %files trans-raw
 %defattr(-, root, root)
@@ -318,6 +374,10 @@ rm -rf $RPM_BUILD_ROOT
 %{_datadir}/emane/xml/transports/raw/transraw.xml
 
 %doc %{_pkgdocdir}
+%if 0%{?_licensedir:1}
+%dir %{_licensedir}/%{name}
+%license %{_licensedir}/%{name}/COPYING
+%endif
 
 %files model-phyapitestshim
 %defattr(-, root, root)
@@ -325,6 +385,10 @@ rm -rf $RPM_BUILD_ROOT
 %{_datadir}/emane/xml/models/shim/phyapitest/phyapitestshim.xml
 
 %doc %{_pkgdocdir}
+%if 0%{?_licensedir:1}
+%dir %{_licensedir}/%{name}
+%license %{_licensedir}/%{name}/COPYING
+%endif
 
 %files model-timinganalysisshim
 %defattr(-, root, root)
@@ -332,6 +396,10 @@ rm -rf $RPM_BUILD_ROOT
 %{_datadir}/emane/xml/models/shim/timinganalysis/timinganalysisshim.xml
 
 %doc %{_pkgdocdir}
+%if 0%{?_licensedir:1}
+%dir %{_licensedir}/%{name}
+%license %{_licensedir}/%{name}/COPYING
+%endif
 
 %files model-commeffect
 %defattr(-,root,root,-)
@@ -341,6 +409,10 @@ rm -rf $RPM_BUILD_ROOT
 %{_datadir}/emane/xml/models/shim/commeffect/commeffectfilters.xml
 
 %doc %{_pkgdocdir}
+%if 0%{?_licensedir:1}
+%dir %{_licensedir}/%{name}
+%license %{_licensedir}/%{name}/COPYING
+%endif
 
 %files model-tdmaeventscheduler
 %defattr(-,root,root,-)
@@ -351,6 +423,10 @@ rm -rf $RPM_BUILD_ROOT
 %{_datadir}/emane/xml/models/mac/tdmaeventscheduler/tdmabasemodelpcr.xml
 
 %doc %{_pkgdocdir}
+%if 0%{?_licensedir:1}
+%dir %{_licensedir}/%{name}
+%license %{_licensedir}/%{name}/COPYING
+%endif
 
 %files gen-eel
 %defattr(-,root,root,-)
@@ -362,9 +438,18 @@ rm -rf $RPM_BUILD_ROOT
 %{_datadir}/emane/xml/generators/eel/eelgenerator.xml
 
 %doc %{_pkgdocdir}
+%if 0%{?_licensedir:1}
+%dir %{_licensedir}/%{name}
+%license %{_licensedir}/%{name}/COPYING
+%endif
 
 %files manifest
 %defattr(-, root, root)
 %{_datadir}/emane/manifest/*.xml
 
 %doc %{_pkgdocdir}
+%if 0%{?_licensedir:1}
+%dir %{_licensedir}/%{name}
+%license %{_licensedir}/%{name}/COPYING
+%endif
+

--- a/emane.spec.in
+++ b/emane.spec.in
@@ -224,6 +224,8 @@ rm -rf $RPM_BUILD_ROOT
 
 %files dtds
 %defattr(-, root, root)
+%dir %{_datadir}/emane
+%dir %{_datadir}/emane/dtd
 %{_datadir}/emane/dtd/attrs.ent
 %{_datadir}/emane/dtd/mac.dtd
 %{_datadir}/emane/dtd/nem.dtd
@@ -242,8 +244,17 @@ rm -rf $RPM_BUILD_ROOT
 %{_datadir}/emane/dtd/ieee80211pcr.dtd
 %{_datadir}/emane/dtd/antennaprofile.dtd
 %{_datadir}/emane/dtd/commeffectfilters.dtd
+%dir %{_datadir}/emane/schema
 %{_datadir}/emane/schema/manifest.xsd
 %{_datadir}/emane/schema/tdmabasemodelpcr.xsd
+%dir %{_datadir}/emane/xml
+%dir %{_datadir}/emane/xml/agents
+%dir %{_datadir}/emane/xml/generators
+%dir %{_datadir}/emane/xml/models
+%dir %{_datadir}/emane/xml/models/mac
+%dir %{_datadir}/emane/xml/models/phy
+%dir %{_datadir}/emane/xml/models/shim
+%dir %{_datadir}/emane/xml/transports
 
 %doc %{_pkgdocdir}
 %if 0%{?_licensedir:1}
@@ -297,6 +308,7 @@ rm -rf $RPM_BUILD_ROOT
 
 %files devel
 %defattr(-, root, root)
+%dir %{_includedir}/emane
 %{_includedir}/emane/*
 %{_libdir}/pkgconfig/*
 
@@ -309,6 +321,7 @@ rm -rf $RPM_BUILD_ROOT
 %files model-rfpipe
 %defattr(-, root, root)
 %{_libdir}/librfpipemaclayer.*
+%dir %{_datadir}/emane/xml/models/mac/rfpipe
 %{_datadir}/emane/xml/models/mac/rfpipe/rfpipemac.xml
 %{_datadir}/emane/xml/models/mac/rfpipe/rfpipenem.xml
 %{_datadir}/emane/xml/models/mac/rfpipe/rfpipepcr.xml
@@ -323,7 +336,9 @@ rm -rf $RPM_BUILD_ROOT
 %defattr(-, root, root)
 %{_libdir}/libbypassmaclayer.*
 %{_libdir}/libbypassphylayer.*
+%dir %{_datadir}/emane/xml/models/phy/bypass
 %{_datadir}/emane/xml/models/phy/bypass/bypassphy.xml
+%dir %{_datadir}/emane/xml/models/mac/bypass
 %{_datadir}/emane/xml/models/mac/bypass/bypassmac.xml
 %{_datadir}/emane/xml/models/mac/bypass/bypassnem.xml
 
@@ -336,6 +351,7 @@ rm -rf $RPM_BUILD_ROOT
 %files model-ieee80211abg
 %defattr(-, root, root)
 %{_libdir}/libieee80211abgmaclayer.*
+%dir %{_datadir}/emane/xml/models/mac/ieee80211abg
 %{_datadir}/emane/xml/models/mac/ieee80211abg/ieee80211abgmac.xml
 %{_datadir}/emane/xml/models/mac/ieee80211abg/ieee80211abgnem.xml
 %{_datadir}/emane/xml/models/mac/ieee80211abg/ieee80211pcr.xml
@@ -349,6 +365,7 @@ rm -rf $RPM_BUILD_ROOT
 %files agent-gpsdlocation
 %defattr(-, root, root)
 %{_libdir}/libgpsdlocationagent.*
+%dir %{_datadir}/emane/xml/agents/gpsdlocation
 %{_datadir}/emane/xml/agents/gpsdlocation/gpsdlocationagent.xml
 
 %doc %{_pkgdocdir}
@@ -360,6 +377,7 @@ rm -rf $RPM_BUILD_ROOT
 %files trans-virtual
 %defattr(-, root, root)
 %{_libdir}/libtransvirtual.*
+%dir %{_datadir}/emane/xml/transports/virtual
 %{_datadir}/emane/xml/transports/virtual/transvirtual.xml
 
 %doc %{_pkgdocdir}
@@ -371,6 +389,7 @@ rm -rf $RPM_BUILD_ROOT
 %files trans-raw
 %defattr(-, root, root)
 %{_libdir}/libtransraw.*
+%dir %{_datadir}/emane/xml/transports/raw
 %{_datadir}/emane/xml/transports/raw/transraw.xml
 
 %doc %{_pkgdocdir}
@@ -382,6 +401,7 @@ rm -rf $RPM_BUILD_ROOT
 %files model-phyapitestshim
 %defattr(-, root, root)
 %{_libdir}/libphyapitestshim.*
+%dir %{_datadir}/emane/xml/models/shim/phyapitest
 %{_datadir}/emane/xml/models/shim/phyapitest/phyapitestshim.xml
 
 %doc %{_pkgdocdir}
@@ -393,6 +413,7 @@ rm -rf $RPM_BUILD_ROOT
 %files model-timinganalysisshim
 %defattr(-, root, root)
 %{_libdir}/libtiminganalysisshim.*
+%dir %{_datadir}/emane/xml/models/shim/timinganalysis
 %{_datadir}/emane/xml/models/shim/timinganalysis/timinganalysisshim.xml
 
 %doc %{_pkgdocdir}
@@ -404,6 +425,7 @@ rm -rf $RPM_BUILD_ROOT
 %files model-commeffect
 %defattr(-,root,root,-)
 %{_libdir}/libcommeffectshim.*
+%dir %{_datadir}/emane/xml/models/shim/commeffect
 %{_datadir}/emane/xml/models/shim/commeffect/commeffectshim.xml
 %{_datadir}/emane/xml/models/shim/commeffect/commeffectnem.xml
 %{_datadir}/emane/xml/models/shim/commeffect/commeffectfilters.xml
@@ -418,6 +440,7 @@ rm -rf $RPM_BUILD_ROOT
 %defattr(-,root,root,-)
 %{_libdir}/libtdmabase.*
 %{_libdir}/libtdmaeventschedulerradiomodel.*
+%dir %{_datadir}/emane/xml/models/mac/tdmaeventscheduler
 %{_datadir}/emane/xml/models/mac/tdmaeventscheduler/tdmanem.xml
 %{_datadir}/emane/xml/models/mac/tdmaeventscheduler/tdmaradiomodel.xml
 %{_datadir}/emane/xml/models/mac/tdmaeventscheduler/tdmabasemodelpcr.xml
@@ -435,6 +458,7 @@ rm -rf $RPM_BUILD_ROOT
 %{_libdir}/libeelloaderpathloss.*
 %{_libdir}/libeelloaderantennaprofile.*
 %{_libdir}/libeelloadercommeffect.*
+%dir %{_datadir}/emane/xml/generators/eel
 %{_datadir}/emane/xml/generators/eel/eelgenerator.xml
 
 %doc %{_pkgdocdir}
@@ -445,6 +469,8 @@ rm -rf $RPM_BUILD_ROOT
 
 %files manifest
 %defattr(-, root, root)
+%dir %{_datadir}/emane
+%dir %{_datadir}/emane/manifest
 %{_datadir}/emane/manifest/*.xml
 
 %doc %{_pkgdocdir}

--- a/emane.spec.in
+++ b/emane.spec.in
@@ -18,6 +18,7 @@ heterogeneous network emulation using a pluggable MAC and PHY layer
 architecture.
 
 %package devel
+Requires: emane-libs = %{version} ace-devel
 Summary: Headers necessary to build EMANE network emulation modules.
 Group: Development/Libraries
 

--- a/emane.spec.in
+++ b/emane.spec.in
@@ -7,7 +7,7 @@ Group: Applications/System
 URL: https://github.com/adjacentlink/emane
 Source0: %{name}-%{version}.tar.gz
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
-Requires: emane-libs >= %{version} emane-dtds >= %{version}
+Requires: emane-libs = %{version} emane-dtds = %{version}
 BuildRequires: libxml2-devel ace-devel protobuf-devel pcre-devel libpcap-devel libuuid-devel
 Prefix: /usr
 Vendor: Adjacent Link LLC
@@ -32,7 +32,7 @@ Group: Applications/System
 EMANE DTDs required for EMANE XML.
 
 %package utils
-Requires: emane-dtds  >= %{version} python-lxml
+Requires: emane-dtds = %{version} python-lxml
 Summary: EMANE utilities
 Group:  Applications/System
 
@@ -47,7 +47,7 @@ Group: Libraries
 EMANE Libraries required for components
 
 %package transportdaemon
-Requires: emane-libs  >= %{version} emane-dtds >= %{version}
+Requires: emane-libs = %{version} emane-dtds = %{version}
 Summary: EMANE transport daemon
 Group: Applications/System
 
@@ -55,7 +55,7 @@ Group: Applications/System
 EMANE transport daemon.  Creates and manages one or more transports.
 
 %package eventdaemon
-Requires: emane-libs >= %{version} emane-dtds >= %{version}
+Requires: emane-libs = %{version} emane-dtds = %{version}
 Summary: EMANE event daemon
 Group: Applications/System
 
@@ -63,7 +63,7 @@ Group: Applications/System
 EMANE event daemon forwards events to registered agents.
 
 %package eventservice
-Requires: emane-libs  >= %{version} emane-dtds >= %{version}
+Requires: emane-libs = %{version} emane-dtds = %{version}
 Summary: EMANE event service
 Group: Applications/System
 
@@ -71,7 +71,7 @@ Group: Applications/System
 EMANE event service creates and manages event generators. 
 
 %package model-rfpipe
-Requires: emane >= %{version}
+Requires: emane = %{version}
 Summary: EMANE RF Pipe MAC Layer
 Group: Libraries
 
@@ -79,7 +79,7 @@ Group: Libraries
 EMANE RF Pipe MAC Layer
 
 %package model-ieee80211abg
-Requires: emane >= %{version}
+Requires: emane = %{version}
 Summary: EMANE  802.11abg MAC Layer
 Group: Libraries
 
@@ -87,7 +87,7 @@ Group: Libraries
 EMANE 802.11abg MAC Layer
 
 %package model-bypass
-Requires: emane >= %{version}
+Requires: emane = %{version}
 Summary: EMANE Bypass MAC and PHY Layer
 Group: Libraries
 
@@ -96,7 +96,7 @@ EMANE Bypass MAC and PHY Layer
 
 %package model-commeffect
 Summary: EMANE commeffect shim model.
-Requires: emane-dtds >= %{version}
+Requires: emane-dtds = %{version}
 Group: Libraries
 
 %description model-commeffect
@@ -104,14 +104,14 @@ EMANE commeffect model replacement for commercial network emulators.
 
 %package model-tdmaeventscheduler
 Summary: EMANE TDMA Event Scheduler radio model.
-Requires: emane-dtds >= %{version}
+Requires: emane-dtds = %{version}
 Group: Libraries
 
 %description model-tdmaeventscheduler
 EMANE TDMA event scheduler model.
 
 %package agent-gpsdlocation
-Requires: emane-eventdaemon >= %{version}
+Requires: emane-eventdaemon = %{version}
 Summary: EMANE gpsd location agent 
 Group: Libraries
 
@@ -120,7 +120,7 @@ EMANE gpsd location agent translates location events into NMEA strings
 and transmits them to gpsd via a pseudo terminal device.
 
 %package trans-virtual
-Requires: emane-transportdaemon >= %{version}
+Requires: emane-transportdaemon = %{version}
 Summary: EMANE virtual transport implementation
 Group: Libraries
 
@@ -129,7 +129,7 @@ EMANE virtual transport.  Uses tun device to create a network layer
 entry point for the NEM stack.
 
 %package trans-raw
-Requires: emane-transportdaemon >= %{version}
+Requires: emane-transportdaemon = %{version}
 Summary: EMANE raw transport implementation
 Group: Libraries
 
@@ -138,7 +138,7 @@ EMANE raw transport.  Uses raw IP to create a network layer
 entry point for the NEM stack.
 
 %package model-phyapitestshim
-Requires: emane >= %{version}
+Requires: emane = %{version}
 Summary: EMANE PHY API Test shim
 Group: Libraries
 
@@ -146,7 +146,7 @@ Group: Libraries
 EMANE PHY API Test shim
 
 %package model-timinganalysisshim
-Requires: emane >= %{version}
+Requires: emane = %{version}
 Summary: EMANE Timing Test shim
 Group: Libraries
 
@@ -154,7 +154,7 @@ Group: Libraries
 EMANE Timing Test shim
 
 %package gen-eel
-Requires: emane >= %{version}
+Requires: emane = %{version}
 Summary: EMANE Emulation Event Log Generator
 Group: Libraries
 

--- a/emane.spec.in
+++ b/emane.spec.in
@@ -12,6 +12,8 @@ BuildRequires: libxml2-devel ace-devel protobuf-devel pcre-devel libpcap-devel l
 Prefix: /usr
 Vendor: Adjacent Link LLC
 
+%{!?_pkgdocdir: %global _pkgdocdir %{_docdir}/%{name}-%{version}}
+
 %description
 EMANE is an Extendable Mobile Ad-hoc Network Emulator that allows for 
 heterogeneous network emulation using a pluggable MAC and PHY layer 
@@ -180,6 +182,8 @@ make %{?_smp_mflags}
 make DESTDIR=${RPM_BUILD_ROOT} install
 find ${RPM_BUILD_ROOT} -name '*.a' -exec rm '{}'  \;
 find ${RPM_BUILD_ROOT} -name '*.la' -exec rm '{}' \;
+mkdir -p ${RPM_BUILD_ROOT}%{_pkgdocdir}
+install -t ${RPM_BUILD_ROOT}%{_pkgdocdir} AUTHORS COPYING ChangeLog NEWS README PROBLEM-REPORT-FORM SPONSOR
 
 %clean
 rm -rf $RPM_BUILD_ROOT
@@ -195,13 +199,7 @@ rm -rf $RPM_BUILD_ROOT
 %{_bindir}/emane
 %{_bindir}/emaneinfo
 
-%doc AUTHORS
-%doc COPYING
-%doc ChangeLog
-%doc NEWS
-%doc README
-%doc PROBLEM-REPORT-FORM
-%doc SPONSOR
+%doc %{_pkgdocdir}
 %doc %{_mandir}/man1/emane.1.gz
 
 %files utils
@@ -209,24 +207,12 @@ rm -rf $RPM_BUILD_ROOT
 %{_bindir}/emanegentransportxml
 %{_bindir}/emaneconvertdtdpath
 
-%doc AUTHORS
-%doc COPYING
-%doc ChangeLog
-%doc NEWS
-%doc README
-%doc PROBLEM-REPORT-FORM
-%doc SPONSOR
+%doc %{_pkgdocdir}
 %doc %{_mandir}/man1/emanegentransportxml.1.gz
 
 %files dtds
 %defattr(-, root, root)
-%doc AUTHORS
-%doc COPYING
-%doc ChangeLog
-%doc NEWS
-%doc README
-%doc PROBLEM-REPORT-FORM
-%doc SPONSOR
+%doc %{_pkgdocdir}
 %doc %{_datadir}/emane/dtd/attrs.ent
 %doc %{_datadir}/emane/dtd/mac.dtd
 %doc %{_datadir}/emane/dtd/nem.dtd
@@ -253,52 +239,27 @@ rm -rf $RPM_BUILD_ROOT
 %{_libdir}/libemanexmlparser.*
 %{_libdir}/libemane.*
 
-%doc AUTHORS
-%doc COPYING
-%doc ChangeLog
-%doc NEWS
-%doc README
-%doc PROBLEM-REPORT-FORM
-%doc SPONSOR
+%doc %{_pkgdocdir}
 
 %files transportdaemon
 %defattr(-, root, root)
 %{_bindir}/emanetransportd
 
-%doc AUTHORS
-%doc COPYING
-%doc ChangeLog
-%doc NEWS
-
-%doc README
-%doc PROBLEM-REPORT-FORM
-%doc SPONSOR
+%doc %{_pkgdocdir}
 %doc %{_mandir}/man1/emanetransportd.1.gz
 
 %files eventdaemon
 %defattr(-, root, root)
 %{_bindir}/emaneeventd
 
-%doc AUTHORS
-%doc COPYING
-%doc ChangeLog
-%doc NEWS
-%doc README
-%doc PROBLEM-REPORT-FORM
-%doc SPONSOR
+%doc %{_pkgdocdir}
 %doc %{_mandir}/man1/emaneeventd.1.gz
 
 %files eventservice
 %defattr(-, root, root)
 %{_bindir}/emaneeventservice
 
-%doc AUTHORS
-%doc COPYING
-%doc ChangeLog
-%doc NEWS
-%doc README
-%doc PROBLEM-REPORT-FORM
-%doc SPONSOR
+%doc %{_pkgdocdir}
 %doc %{_mandir}/man1/emaneeventservice.1.gz
 
 %files devel
@@ -306,25 +267,13 @@ rm -rf $RPM_BUILD_ROOT
 %{_includedir}/emane/*
 %{_libdir}/pkgconfig/*
 
-%doc AUTHORS
-%doc COPYING
-%doc ChangeLog
-%doc NEWS
-%doc README
-%doc PROBLEM-REPORT-FORM
-%doc SPONSOR
+%doc %{_pkgdocdir}
 
 %files model-rfpipe
 %defattr(-, root, root)
 %{_libdir}/librfpipemaclayer.*
 
-%doc AUTHORS
-%doc COPYING
-%doc ChangeLog
-%doc NEWS
-%doc README
-%doc PROBLEM-REPORT-FORM
-%doc SPONSOR
+%doc %{_pkgdocdir}
 %doc %{_datadir}/emane/xml/models/mac/rfpipe/rfpipemac.xml
 %doc %{_datadir}/emane/xml/models/mac/rfpipe/rfpipenem.xml
 %doc %{_datadir}/emane/xml/models/mac/rfpipe/rfpipepcr.xml
@@ -334,13 +283,7 @@ rm -rf $RPM_BUILD_ROOT
 %{_libdir}/libbypassmaclayer.*
 %{_libdir}/libbypassphylayer.*
 
-%doc AUTHORS
-%doc COPYING
-%doc ChangeLog
-%doc NEWS
-%doc README
-%doc PROBLEM-REPORT-FORM
-%doc SPONSOR
+%doc %{_pkgdocdir}
 %doc %{_datadir}/emane/xml/models/phy/bypass/bypassphy.xml
 %doc %{_datadir}/emane/xml/models/mac/bypass/bypassmac.xml
 %doc %{_datadir}/emane/xml/models/mac/bypass/bypassnem.xml
@@ -349,12 +292,7 @@ rm -rf $RPM_BUILD_ROOT
 %defattr(-, root, root)
 %{_libdir}/libieee80211abgmaclayer.*
 
-%doc AUTHORS
-%doc COPYING
-%doc ChangeLog
-%doc NEWS
-%doc PROBLEM-REPORT-FORM
-%doc SPONSOR
+%doc %{_pkgdocdir}
 %doc %{_datadir}/emane/xml/models/mac/ieee80211abg/ieee80211abgmac.xml
 %doc %{_datadir}/emane/xml/models/mac/ieee80211abg/ieee80211abgnem.xml
 %doc %{_datadir}/emane/xml/models/mac/ieee80211abg/ieee80211pcr.xml
@@ -364,72 +302,42 @@ rm -rf $RPM_BUILD_ROOT
 %defattr(-, root, root)
 %{_libdir}/libgpsdlocationagent.*
 
-%doc AUTHORS
-%doc COPYING
-%doc ChangeLog
-%doc NEWS
-%doc PROBLEM-REPORT-FORM
-%doc SPONSOR
+%doc %{_pkgdocdir}
 %doc %{_datadir}/emane/xml/agents/gpsdlocation/gpsdlocationagent.xml
 
 %files trans-virtual
 %defattr(-, root, root)
 %{_libdir}/libtransvirtual.*
 
-%doc AUTHORS
-%doc COPYING
-%doc ChangeLog
-%doc NEWS
-%doc PROBLEM-REPORT-FORM
-%doc SPONSOR
+%doc %{_pkgdocdir}
 %doc %{_datadir}/emane/xml/transports/virtual/transvirtual.xml
 
 %files trans-raw
 %defattr(-, root, root)
 %{_libdir}/libtransraw.*
 
-%doc AUTHORS
-%doc COPYING
-%doc ChangeLog
-%doc NEWS
-%doc PROBLEM-REPORT-FORM
-%doc SPONSOR
+%doc %{_pkgdocdir}
 %doc %{_datadir}/emane/xml/transports/raw/transraw.xml
 
 %files model-phyapitestshim
 %defattr(-, root, root)
 %{_libdir}/libphyapitestshim.*
 
-%doc AUTHORS
-%doc COPYING
-%doc ChangeLog
-%doc NEWS
-%doc PROBLEM-REPORT-FORM
-%doc SPONSOR
+%doc %{_pkgdocdir}
 %doc %{_datadir}/emane/xml/models/shim/phyapitest/phyapitestshim.xml
 
 %files model-timinganalysisshim
 %defattr(-, root, root)
 %{_libdir}/libtiminganalysisshim.*
 
-%doc AUTHORS
-%doc COPYING
-%doc ChangeLog
-%doc NEWS
-%doc PROBLEM-REPORT-FORM
-%doc SPONSOR
+%doc %{_pkgdocdir}
 %doc %{_datadir}/emane/xml/models/shim/timinganalysis/timinganalysisshim.xml
 
 %files model-commeffect
 %defattr(-,root,root,-)
 %{_libdir}/libcommeffectshim.*
 
-%doc AUTHORS
-%doc COPYING
-%doc ChangeLog
-%doc NEWS
-%doc README
-%doc SPONSOR
+%doc %{_pkgdocdir}
 %doc %{_datadir}/emane/xml/models/shim/commeffect/commeffectshim.xml
 %doc %{_datadir}/emane/xml/models/shim/commeffect/commeffectnem.xml
 %doc %{_datadir}/emane/xml/models/shim/commeffect/commeffectfilters.xml
@@ -439,12 +347,7 @@ rm -rf $RPM_BUILD_ROOT
 %{_libdir}/libtdmabase.*
 %{_libdir}/libtdmaeventschedulerradiomodel.*
 
-%doc AUTHORS
-%doc COPYING
-%doc ChangeLog
-%doc NEWS
-%doc README
-%doc SPONSOR
+%doc %{_pkgdocdir}
 %doc %{_datadir}/emane/xml/models/mac/tdmaeventscheduler/tdmanem.xml
 %doc %{_datadir}/emane/xml/models/mac/tdmaeventscheduler/tdmaradiomodel.xml
 %doc %{_datadir}/emane/xml/models/mac/tdmaeventscheduler/tdmabasemodelpcr.xml
@@ -457,21 +360,10 @@ rm -rf $RPM_BUILD_ROOT
 %{_libdir}/libeelloaderantennaprofile.*
 %{_libdir}/libeelloadercommeffect.*
 
-%doc AUTHORS
-%doc COPYING
-%doc ChangeLog
-%doc NEWS
-%doc README
-%doc SPONSOR
+%doc %{_pkgdocdir}
 %doc %{_datadir}/emane/xml/generators/eel/eelgenerator.xml
 
 %files manifest
 %defattr(-, root, root)
-%doc AUTHORS
-%doc COPYING
-%doc ChangeLog
-%doc NEWS
-%doc README
-%doc PROBLEM-REPORT-FORM
-%doc SPONSOR
+%doc %{_pkgdocdir}
 %doc %{_datadir}/emane/manifest/*.xml

--- a/emane.spec.in
+++ b/emane.spec.in
@@ -7,7 +7,7 @@ Group: Applications/System
 URL: https://github.com/adjacentlink/emane
 Source0: %{name}-%{version}.tar.gz
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
-Requires: libxml2 ace protobuf pcre emane-libs >= %{version} emane-dtds >= %{version}
+Requires: emane-libs >= %{version} emane-dtds >= %{version}
 BuildRequires: libxml2-devel ace-devel protobuf-devel pcre-devel libpcap-devel libuuid-devel
 Prefix: /usr
 Vendor: Adjacent Link LLC
@@ -40,7 +40,6 @@ Group:  Applications/System
 EMANE utilities
 
 %package libs
-Requires: libxml2 ace
 Summary: EMANE Libraries
 Group: Libraries
 

--- a/emane.spec.in
+++ b/emane.spec.in
@@ -97,7 +97,7 @@ EMANE Bypass MAC and PHY Layer
 
 %package model-commeffect
 Summary: EMANE commeffect shim model.
-Requires: emane-dtds = %{version}
+Requires: emane = %{version}
 Group: Libraries
 
 %description model-commeffect
@@ -105,7 +105,7 @@ EMANE commeffect model replacement for commercial network emulators.
 
 %package model-tdmaeventscheduler
 Summary: EMANE TDMA Event Scheduler radio model.
-Requires: emane-dtds = %{version}
+Requires: emane = %{version}
 Group: Libraries
 
 %description model-tdmaeventscheduler

--- a/emane.spec.in
+++ b/emane.spec.in
@@ -198,41 +198,42 @@ rm -rf $RPM_BUILD_ROOT
 %defattr(-,root,root,-)
 %{_bindir}/emane
 %{_bindir}/emaneinfo
+%{_mandir}/man1/emane.1.gz
 
 %doc %{_pkgdocdir}
-%doc %{_mandir}/man1/emane.1.gz
 
 %files utils
 %defattr(-, root, root)
 %{_bindir}/emanegentransportxml
 %{_bindir}/emaneconvertdtdpath
+%{_mandir}/man1/emanegentransportxml.1.gz
 
 %doc %{_pkgdocdir}
-%doc %{_mandir}/man1/emanegentransportxml.1.gz
 
 %files dtds
 %defattr(-, root, root)
+%{_datadir}/emane/dtd/attrs.ent
+%{_datadir}/emane/dtd/mac.dtd
+%{_datadir}/emane/dtd/nem.dtd
+%{_datadir}/emane/dtd/nemcontents.dtd
+%{_datadir}/emane/dtd/param.dtd
+%{_datadir}/emane/dtd/phy.dtd
+%{_datadir}/emane/dtd/platform.dtd
+%{_datadir}/emane/dtd/shim.dtd
+%{_datadir}/emane/dtd/transport.dtd
+%{_datadir}/emane/dtd/transportdaemon.dtd
+%{_datadir}/emane/dtd/eventagent.dtd
+%{_datadir}/emane/dtd/eventdaemon.dtd
+%{_datadir}/emane/dtd/eventgenerator.dtd
+%{_datadir}/emane/dtd/eventservice.dtd
+%{_datadir}/emane/dtd/rfpipepcr.dtd
+%{_datadir}/emane/dtd/ieee80211pcr.dtd
+%{_datadir}/emane/dtd/antennaprofile.dtd
+%{_datadir}/emane/dtd/commeffectfilters.dtd
+%{_datadir}/emane/schema/manifest.xsd
+%{_datadir}/emane/schema/tdmabasemodelpcr.xsd
+
 %doc %{_pkgdocdir}
-%doc %{_datadir}/emane/dtd/attrs.ent
-%doc %{_datadir}/emane/dtd/mac.dtd
-%doc %{_datadir}/emane/dtd/nem.dtd
-%doc %{_datadir}/emane/dtd/nemcontents.dtd
-%doc %{_datadir}/emane/dtd/param.dtd
-%doc %{_datadir}/emane/dtd/phy.dtd
-%doc %{_datadir}/emane/dtd/platform.dtd
-%doc %{_datadir}/emane/dtd/shim.dtd
-%doc %{_datadir}/emane/dtd/transport.dtd
-%doc %{_datadir}/emane/dtd/transportdaemon.dtd
-%doc %{_datadir}/emane/dtd/eventagent.dtd
-%doc %{_datadir}/emane/dtd/eventdaemon.dtd
-%doc %{_datadir}/emane/dtd/eventgenerator.dtd
-%doc %{_datadir}/emane/dtd/eventservice.dtd
-%doc %{_datadir}/emane/dtd/rfpipepcr.dtd
-%doc %{_datadir}/emane/dtd/ieee80211pcr.dtd
-%doc %{_datadir}/emane/dtd/antennaprofile.dtd
-%doc %{_datadir}/emane/dtd/commeffectfilters.dtd
-%doc %{_datadir}/emane/schema/manifest.xsd
-%doc %{_datadir}/emane/schema/tdmabasemodelpcr.xsd
 
 %files libs
 %defattr(-, root, root)
@@ -244,23 +245,23 @@ rm -rf $RPM_BUILD_ROOT
 %files transportdaemon
 %defattr(-, root, root)
 %{_bindir}/emanetransportd
+%{_mandir}/man1/emanetransportd.1.gz
 
 %doc %{_pkgdocdir}
-%doc %{_mandir}/man1/emanetransportd.1.gz
 
 %files eventdaemon
 %defattr(-, root, root)
 %{_bindir}/emaneeventd
+%{_mandir}/man1/emaneeventd.1.gz
 
 %doc %{_pkgdocdir}
-%doc %{_mandir}/man1/emaneeventd.1.gz
 
 %files eventservice
 %defattr(-, root, root)
 %{_bindir}/emaneeventservice
+%{_mandir}/man1/emaneeventservice.1.gz
 
 %doc %{_pkgdocdir}
-%doc %{_mandir}/man1/emaneeventservice.1.gz
 
 %files devel
 %defattr(-, root, root)
@@ -272,85 +273,84 @@ rm -rf $RPM_BUILD_ROOT
 %files model-rfpipe
 %defattr(-, root, root)
 %{_libdir}/librfpipemaclayer.*
+%{_datadir}/emane/xml/models/mac/rfpipe/rfpipemac.xml
+%{_datadir}/emane/xml/models/mac/rfpipe/rfpipenem.xml
+%{_datadir}/emane/xml/models/mac/rfpipe/rfpipepcr.xml
 
 %doc %{_pkgdocdir}
-%doc %{_datadir}/emane/xml/models/mac/rfpipe/rfpipemac.xml
-%doc %{_datadir}/emane/xml/models/mac/rfpipe/rfpipenem.xml
-%doc %{_datadir}/emane/xml/models/mac/rfpipe/rfpipepcr.xml
 
 %files model-bypass
 %defattr(-, root, root)
 %{_libdir}/libbypassmaclayer.*
 %{_libdir}/libbypassphylayer.*
+%{_datadir}/emane/xml/models/phy/bypass/bypassphy.xml
+%{_datadir}/emane/xml/models/mac/bypass/bypassmac.xml
+%{_datadir}/emane/xml/models/mac/bypass/bypassnem.xml
 
 %doc %{_pkgdocdir}
-%doc %{_datadir}/emane/xml/models/phy/bypass/bypassphy.xml
-%doc %{_datadir}/emane/xml/models/mac/bypass/bypassmac.xml
-%doc %{_datadir}/emane/xml/models/mac/bypass/bypassnem.xml
 
 %files model-ieee80211abg
 %defattr(-, root, root)
 %{_libdir}/libieee80211abgmaclayer.*
+%{_datadir}/emane/xml/models/mac/ieee80211abg/ieee80211abgmac.xml
+%{_datadir}/emane/xml/models/mac/ieee80211abg/ieee80211abgnem.xml
+%{_datadir}/emane/xml/models/mac/ieee80211abg/ieee80211pcr.xml
 
 %doc %{_pkgdocdir}
-%doc %{_datadir}/emane/xml/models/mac/ieee80211abg/ieee80211abgmac.xml
-%doc %{_datadir}/emane/xml/models/mac/ieee80211abg/ieee80211abgnem.xml
-%doc %{_datadir}/emane/xml/models/mac/ieee80211abg/ieee80211pcr.xml
-
 
 %files agent-gpsdlocation
 %defattr(-, root, root)
 %{_libdir}/libgpsdlocationagent.*
+%{_datadir}/emane/xml/agents/gpsdlocation/gpsdlocationagent.xml
 
 %doc %{_pkgdocdir}
-%doc %{_datadir}/emane/xml/agents/gpsdlocation/gpsdlocationagent.xml
 
 %files trans-virtual
 %defattr(-, root, root)
 %{_libdir}/libtransvirtual.*
+%{_datadir}/emane/xml/transports/virtual/transvirtual.xml
 
 %doc %{_pkgdocdir}
-%doc %{_datadir}/emane/xml/transports/virtual/transvirtual.xml
 
 %files trans-raw
 %defattr(-, root, root)
 %{_libdir}/libtransraw.*
+%{_datadir}/emane/xml/transports/raw/transraw.xml
 
 %doc %{_pkgdocdir}
-%doc %{_datadir}/emane/xml/transports/raw/transraw.xml
 
 %files model-phyapitestshim
 %defattr(-, root, root)
 %{_libdir}/libphyapitestshim.*
+%{_datadir}/emane/xml/models/shim/phyapitest/phyapitestshim.xml
 
 %doc %{_pkgdocdir}
-%doc %{_datadir}/emane/xml/models/shim/phyapitest/phyapitestshim.xml
 
 %files model-timinganalysisshim
 %defattr(-, root, root)
 %{_libdir}/libtiminganalysisshim.*
+%{_datadir}/emane/xml/models/shim/timinganalysis/timinganalysisshim.xml
 
 %doc %{_pkgdocdir}
-%doc %{_datadir}/emane/xml/models/shim/timinganalysis/timinganalysisshim.xml
 
 %files model-commeffect
 %defattr(-,root,root,-)
 %{_libdir}/libcommeffectshim.*
+%{_datadir}/emane/xml/models/shim/commeffect/commeffectshim.xml
+%{_datadir}/emane/xml/models/shim/commeffect/commeffectnem.xml
+%{_datadir}/emane/xml/models/shim/commeffect/commeffectfilters.xml
 
 %doc %{_pkgdocdir}
-%doc %{_datadir}/emane/xml/models/shim/commeffect/commeffectshim.xml
-%doc %{_datadir}/emane/xml/models/shim/commeffect/commeffectnem.xml
-%doc %{_datadir}/emane/xml/models/shim/commeffect/commeffectfilters.xml
 
 %files model-tdmaeventscheduler
 %defattr(-,root,root,-)
 %{_libdir}/libtdmabase.*
 %{_libdir}/libtdmaeventschedulerradiomodel.*
+%{_datadir}/emane/xml/models/mac/tdmaeventscheduler/tdmanem.xml
+%{_datadir}/emane/xml/models/mac/tdmaeventscheduler/tdmaradiomodel.xml
+%{_datadir}/emane/xml/models/mac/tdmaeventscheduler/tdmabasemodelpcr.xml
 
 %doc %{_pkgdocdir}
-%doc %{_datadir}/emane/xml/models/mac/tdmaeventscheduler/tdmanem.xml
-%doc %{_datadir}/emane/xml/models/mac/tdmaeventscheduler/tdmaradiomodel.xml
-%doc %{_datadir}/emane/xml/models/mac/tdmaeventscheduler/tdmabasemodelpcr.xml
 
 %files gen-eel
 %defattr(-,root,root,-)
@@ -359,11 +359,12 @@ rm -rf $RPM_BUILD_ROOT
 %{_libdir}/libeelloaderpathloss.*
 %{_libdir}/libeelloaderantennaprofile.*
 %{_libdir}/libeelloadercommeffect.*
+%{_datadir}/emane/xml/generators/eel/eelgenerator.xml
 
 %doc %{_pkgdocdir}
-%doc %{_datadir}/emane/xml/generators/eel/eelgenerator.xml
 
 %files manifest
 %defattr(-, root, root)
+%{_datadir}/emane/manifest/*.xml
+
 %doc %{_pkgdocdir}
-%doc %{_datadir}/emane/manifest/*.xml

--- a/emane.spec.in
+++ b/emane.spec.in
@@ -174,7 +174,7 @@ EMANE Plugin Manifests
 
 %build
 %configure
-make
+make %{?_smp_mflags}
 
 %install
 make DESTDIR=${RPM_BUILD_ROOT} install

--- a/emane.spec.in
+++ b/emane.spec.in
@@ -8,7 +8,7 @@ URL: https://github.com/adjacentlink/emane
 Source0: %{name}-%{version}.tar.gz
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
 Requires: libxml2 ace protobuf pcre emane-libs >= %{version} emane-dtds >= %{version}
-BuildRequires: libxml2-devel ace-devel protobuf-devel pcre-devel libpcap-devel
+BuildRequires: libxml2-devel ace-devel protobuf-devel pcre-devel libpcap-devel libuuid-devel
 Prefix: /usr
 Vendor: Adjacent Link LLC
 

--- a/emane.spec.in
+++ b/emane.spec.in
@@ -252,7 +252,6 @@ rm -rf $RPM_BUILD_ROOT
 %defattr(-, root, root)
 %{_libdir}/libemanexmlparser.*
 %{_libdir}/libemane.*
-%{_libdir}/pkgconfig/*
 
 %doc AUTHORS
 %doc COPYING
@@ -305,6 +304,7 @@ rm -rf $RPM_BUILD_ROOT
 %files devel
 %defattr(-, root, root)
 %{_includedir}/emane/*
+%{_libdir}/pkgconfig/*
 
 %doc AUTHORS
 %doc COPYING

--- a/src/emanesh/Makefile.am
+++ b/src/emanesh/Makefile.am
@@ -127,7 +127,7 @@ setup.py:	setup.py.in
 rpm: $(BUILT_SOURCES)
 	$(PYTHON) setup.py bdist_rpm  \
    --vendor "Adjacent Link LLC" \
-   --requires "protobuf-python python-setuptools"
+   --requires "protobuf-python python-lxml"
 
 stdeb.cfg: stdeb.cfg.in
 	if test -f $@; then chmod u+w $@; fi

--- a/src/emanesh/Makefile.in
+++ b/src/emanesh/Makefile.in
@@ -583,7 +583,7 @@ setup.py:	setup.py.in
 rpm: $(BUILT_SOURCES)
 	$(PYTHON) setup.py bdist_rpm  \
    --vendor "Adjacent Link LLC" \
-   --requires "protobuf-python python-setuptools"
+   --requires "protobuf-python python-lxml"
 
 stdeb.cfg: stdeb.cfg.in
 	if test -f $@; then chmod u+w $@; fi

--- a/src/models/mac/bypass/bypassnem.xml.in
+++ b/src/models/mac/bypass/bypassnem.xml.in
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE nem SYSTEM "file://@datadir@/dtd/nem.dtd">
 <nem name="BYPASS NEM">
-  <mac definition="bypassmac.xml"/>
-  <phy definition="bypassphy.xml"/>
   <transport definition="transvirtual.xml">
     <param name="mask" value="255.255.255.0" />
     <param name="device" value="emane0" />
     <param name="devicepath" value="/dev/net/tun" />
     <param name="bitrate" value="1024" />
   </transport>
+  <mac definition="bypassmac.xml"/>
+  <phy definition="bypassphy.xml"/>
 </nem>

--- a/src/models/mac/ieee80211abg/ieee80211abgnem.xml.in
+++ b/src/models/mac/ieee80211abg/ieee80211abgnem.xml.in
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE nem SYSTEM "file://@datadir@/dtd/nem.dtd">
 <nem name="IEEE 802.11 NEM">
+  <transport definition="transvirtual.xml"/>
   <mac definition="ieee80211abgmac.xml"/>
   <phy>
     <param name="fixedantennagain"         value="0.0"/>
@@ -9,9 +10,7 @@
     <param name="noisemode"                value="none"/>
     <param name="propagationmodel"         value="precomputed"/>
     <param name="systemnoisefigure"        value="4.0"/>
-    <param name="subid"                    value="2"/>
     <param name="txpower"                  value="0.0"/>
     <param name="subid"                    value="1"/>
   </phy>
-  <transport definition="transvirtual.xml"/>
 </nem>

--- a/src/models/mac/rfpipe/rfpipenem.xml.in
+++ b/src/models/mac/rfpipe/rfpipenem.xml.in
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE nem SYSTEM "file://@datadir@/dtd/nem.dtd">
 <nem name="RF-PIPE NEM">
+  <transport definition="transvirtual.xml"/>
   <mac definition="rfpipemac.xml"/>
   <phy>
     <param name="fixedantennagain"         value="0.0"/>
@@ -12,5 +13,4 @@
     <param name="subid"                    value="2"/>
     <param name="txpower"                  value="0.0"/>
   </phy>
-  <transport definition="transvirtual.xml"/>
 </nem>

--- a/src/models/shim/commeffect/commeffectnem.xml.in
+++ b/src/models/shim/commeffect/commeffectnem.xml.in
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE nem SYSTEM "file:///usr/share/emane/dtd/nem.dtd">
 <nem name="COMMEFFECT NEM" type="unstructured">
-  <shim definition="commeffectshim.xml"/>
   <transport definition="transraw.xml"/>
+  <shim definition="commeffectshim.xml"/>
 </nem>


### PR DESCRIPTION
Please pull these changes to fix DTD conformance of the sample NEM configurations, and to fix several issues with RPM package building and dependencies. These were tested on RHEL 6, Fedora 21, and Fedora 23 (still in development).

I was unable to reproduce any issue with autotools disabling compiler optimizations when the '-g' flag is present &mdash; I tried on Fedora 21 which has the same autoconf/automake version that you used, and I also tried in Fedora 23 (still in development).