### PR TITLE
feature/issue30

### DIFF
--- a/src/emanesh/emanesh/events/eventservice.py
+++ b/src/emanesh/emanesh/events/eventservice.py
@@ -221,8 +221,9 @@ class EventService:
     def nextEvent(self):
         events = []
         eventId = 0
+        running = True
 
-        while True:
+        while running:
             try:
                 rdfds = [self._socket,self._readFd]
 
@@ -257,6 +258,10 @@ class EventService:
                                 event.sequenceNumber,
                                 tuple(events))
 
+                elif fd is self._readFd:
+                    running = False
+                    break
+
                 elif fd is self._socketOTA:
                     data,_ = self._socketOTA.recvfrom(65535)
                     
@@ -282,6 +287,8 @@ class EventService:
                     return (uuid.UUID(bytes=otaHeader.uuid),
                             otaHeader.sequenceNumber,
                             tuple(events))
+
+        return (None, None, tuple(events))
 
 
     def subscribe(self,eventId,callback):


### PR DESCRIPTION
Fixed emanesh.events.EventService getNext() cancellation logic on breakloop(). Added missing logic to use internal pipe to signal getNext() to return. On cancel via breakloop() or on a socket read error, getNext() will return (None,None,()) for the UUID, sequence number and event data, respectively.

Submitted-by: Tom Goff <https://github.com/tomgoff>
See https://github.com/adjacentlink/emane/issues/30