### PR TITLE
feature/txdelayenhancement

### DIFF
--- a/src/models/mac/ieee80211abg/maclayer.cc
+++ b/src/models/mac/ieee80211abg/maclayer.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2014 - Adjacent Link LLC, Bridgewater, New Jersey
+ * Copyright (c) 2013-2015 - Adjacent Link LLC, Bridgewater, New Jersey
  * Copyright (c) 2008-2012 - DRS CenGen, LLC, Columbia, Maryland
  * All rights reserved.
  *
@@ -123,7 +123,8 @@ EMANE::Models::IEEE80211ABG::MACLayer::MACLayer(NEMId id,
   downstreamQueueTimedEventId_{},
   bHasPendingDownstreamQueueEntry_{},
   RNDZeroToOne_{0.0f, 1.0f},
-  commonLayerStatistics_(MAX_ACCESS_CATEGORIES)
+  commonLayerStatistics_(MAX_ACCESS_CATEGORIES),
+  currentEndOfTransmissionTime_{}
 {
   commonLayerStatistics_[0].reset(
     new Utils::CommonLayerStatistics{STATISTIC_TABLE_LABELS,
@@ -1190,6 +1191,12 @@ EMANE::Models::IEEE80211ABG::MACLayer::processDownstreamPacket(DownstreamPacket 
           // drop, replace token
           addToken();
         }
+
+      // check to see if a packet can be sent
+      if(currentEndOfTransmissionTime_ <= Clock::now())
+        {
+          handleDownstreamQueueEntry(u64SequenceNumber_);
+        }
     }
   else
     {
@@ -1205,11 +1212,12 @@ EMANE::Models::IEEE80211ABG::MACLayer::processDownstreamPacket(DownstreamPacket 
             pPlatformService_->timerService().
             scheduleTimedEvent(optionalWait.first,
                                new std::function<bool()>{std::bind(&MACLayer::handleDownstreamQueueEntry,
-                                                                   this)});
+                                                                   this,
+                                                                   u64SequenceNumber_)});
         }
       else
         {
-          handleDownstreamQueueEntry();
+          handleDownstreamQueueEntry(u64SequenceNumber_);
         }
     }
 }
@@ -1393,7 +1401,9 @@ EMANE::Models::IEEE80211ABG::MACLayer::sendDownstreamMessage(DownstreamQueueEntr
                        {Controls::FrequencyControlMessage::create(
                          0,                                                 // bandwidth (0 uses phy default)
                          {{0,rMACHeaderParams.getDurationMicroseconds()}}), // freq (0 uses phy default)
-                       Controls::TimeStampControlMessage::create(entry.txTime_)}); 
+                       Controls::TimeStampControlMessage::create(entry.txTime_)});
+
+  currentEndOfTransmissionTime_ = currentTime + entry.durationMicroseconds_ + overheadMicroseconds;
 }
 
 
@@ -1817,42 +1827,46 @@ EMANE::Models::IEEE80211ABG::MACLayer::checkForRxCollision(NEMId src, std::uint8
 }
 
 
-bool EMANE::Models::IEEE80211ABG::MACLayer::handleDownstreamQueueEntry()
+bool EMANE::Models::IEEE80211ABG::MACLayer::handleDownstreamQueueEntry(std::uint64_t u64SequenceNumber)
 {
-  // there are two ways to end processing: schedule a timer or have no
-  //  other packets in the downstream queue once you finish processing
-  //  the pending packet
-  while(bHasPendingDownstreamQueueEntry_)
+  if(u64SequenceNumber == u64SequenceNumber_)
     {
-      // if there is no further processing for the pending packet
-      //  update the state and see if there is another packet
-      //  pending
-      if(!pTxState_->process(this,pendingDownstreamQueueEntry_))
+      // there are two ways to end processing: schedule a timer or have no
+      //  other packets in the downstream queue once you finish processing
+      //  the pending packet
+      while(bHasPendingDownstreamQueueEntry_)
         {
-          pTxState_->update(this,pendingDownstreamQueueEntry_);
-
-          std::tie(pendingDownstreamQueueEntry_,bHasPendingDownstreamQueueEntry_) =
-            downstreamQueue_.dequeue();
-
-          addToken();
-        }
-
-      // if something is pending we need to schedule it - this could be the
-      // same packet entry that we began with
-      if(bHasPendingDownstreamQueueEntry_)
-        {
-          auto optionalWait = pTxState_->getWaitTime(pendingDownstreamQueueEntry_);
-
-          if(optionalWait.second && optionalWait.first > Clock::now())
+          // if there is no further processing for the pending packet
+          //  update the state and see if there is another packet
+          //  pending
+          if(!pTxState_->process(this,pendingDownstreamQueueEntry_))
             {
-              downstreamQueueTimedEventId_ =
-                pPlatformService_->timerService().
-                scheduleTimedEvent(optionalWait.first,
-                                   new std::function<bool()>{std::bind(&MACLayer::handleDownstreamQueueEntry,
-                                                                       this)});
+              pTxState_->update(this,pendingDownstreamQueueEntry_);
 
-              // we are finished handling the queue entry (for now)
-              break;
+              std::tie(pendingDownstreamQueueEntry_,bHasPendingDownstreamQueueEntry_) =
+                downstreamQueue_.dequeue();
+
+              addToken();
+            }
+
+          // if something is pending we need to schedule it - this could be the
+          // same packet entry that we began with
+          if(bHasPendingDownstreamQueueEntry_)
+            {
+              auto optionalWait = pTxState_->getWaitTime(pendingDownstreamQueueEntry_);
+
+              if(optionalWait.second && optionalWait.first > Clock::now())
+                {
+                  downstreamQueueTimedEventId_ =
+                    pPlatformService_->timerService().
+                    scheduleTimedEvent(optionalWait.first,
+                                       new std::function<bool()>{std::bind(&MACLayer::handleDownstreamQueueEntry,
+                                                                           this,
+                                                                           u64SequenceNumber_)});
+
+                  // we are finished handling the queue entry (for now)
+                  break;
+                }
             }
         }
     }

--- a/src/models/mac/ieee80211abg/maclayer.h
+++ b/src/models/mac/ieee80211abg/maclayer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2014 - Adjacent Link LLC, Bridgewater, New Jersey
+ * Copyright (c) 2013-2015 - Adjacent Link LLC, Bridgewater, New Jersey
  * Copyright (c) 2008-2012 - DRS CenGen, LLC, Columbia, Maryland
  * All rights reserved.
  *
@@ -340,7 +340,9 @@ namespace EMANE
 
         std::vector<std::unique_ptr<Utils::CommonLayerStatistics>> commonLayerStatistics_;
 
-        bool handleDownstreamQueueEntry();
+        TimePoint currentEndOfTransmissionTime_;
+
+        bool handleDownstreamQueueEntry(std::uint64_t u64SequenceNumber);
 
         void setEntrySequenceNumber(DownstreamQueueEntry &entry);
 

--- a/src/models/mac/rfpipe/downstreamqueue.h
+++ b/src/models/mac/rfpipe/downstreamqueue.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2014 - Adjacent Link LLC, Bridgewater, New Jersey
+ * Copyright (c) 2013-2015 - Adjacent Link LLC, Bridgewater, New Jersey
  * Copyright (c) 2010 - DRS CenGen, LLC, Columbia, Maryland
  * All rights reserved.
  *
@@ -56,14 +56,12 @@ namespace EMANE
       struct DownstreamQueueEntry 
       {
         DownstreamPacket pkt_;              // packet payload
-        std::uint64_t u64SequenceNumber_;   // packet sequence number
         TimePoint acquireTime_;             // packet acquire time (absolute time)
         Microseconds durationMicroseconds_; // packet transmission duration
         std::uint64_t u64DataRatebps_;      // packet data rate bps
 
         DownstreamQueueEntry() :
           pkt_{DownstreamPacket{EMANE::PacketInfo{0,0,0,{}},nullptr,0}},
-          u64SequenceNumber_{},
           acquireTime_{},
           durationMicroseconds_{},
           u64DataRatebps_{}
@@ -75,19 +73,16 @@ namespace EMANE
          * @brief  initializer
          *
          * @param pkt                  reference to the downstream packet
-         * @param u64SequenceNumber    sequence number
          * @param acquireTime          acquireTimetart of transmission
          * @param durationMicroseconds duration of transmision
          * @param u64DataRatebps       data rate bps
          */
 
         DownstreamQueueEntry(DownstreamPacket & pkt, 
-                             std::uint64_t u64SequenceNumber, 
                              const TimePoint & acquireTime,
                              const Microseconds & durationMicroseconds,
                              std::uint64_t u64DataRatebps) :
           pkt_{std::move(pkt)},
-          u64SequenceNumber_{u64SequenceNumber},
           acquireTime_{acquireTime},
           durationMicroseconds_{durationMicroseconds},
           u64DataRatebps_{u64DataRatebps}

--- a/src/models/mac/rfpipe/maclayer.cc
+++ b/src/models/mac/rfpipe/maclayer.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2014 - Adjacent Link LLC, Bridgewater, New Jersey
+ * Copyright (c) 2013-2015 - Adjacent Link LLC, Bridgewater, New Jersey
  * Copyright (c) 2008-2009 - DRS CenGen, LLC, Columbia, Maryland
  * All rights reserved.
  *
@@ -93,7 +93,8 @@ EMANE::Models::RFPipe::MACLayer::MACLayer(NEMId id,
   pNumDownstreamQueueDelay_{},
   downstreamQueueTimedEventId_{},
   bHasPendingDownstreamQueueEntry_{},
-  pendingDownstreamQueueEntry_{}
+  pendingDownstreamQueueEntry_{},
+  currentEndOfTransmissionTime_{}
 {}
 
 EMANE::Models::RFPipe::MACLayer::~MACLayer(){}
@@ -1032,13 +1033,10 @@ EMANE::Models::RFPipe::MACLayer::processDownstreamPacket(DownstreamPacket & pkt,
   Microseconds durationMicroseconds{getDurationMicroseconds(pkt.length())};
   
   DownstreamQueueEntry entry{pkt,                   // pkt
-      u64TxSequenceNumber_,  // sequence number
       beginTime,             // acquire time
       durationMicroseconds,  // duration
       u64DataRatebps_};      // data rate
-  
-  ++u64TxSequenceNumber_;
-  
+
   if(bHasPendingDownstreamQueueEntry_)
     {
       std::vector<DownstreamQueueEntry> result{downstreamQueue_.enqueue(entry)};
@@ -1067,6 +1065,14 @@ EMANE::Models::RFPipe::MACLayer::processDownstreamPacket(DownstreamPacket & pkt,
                 }
             }
         }
+
+      // check to see if a packet can be sent
+      if(currentEndOfTransmissionTime_ + delayMicroseconds_ + getJitter() <= Clock::now())
+        {
+          TimePoint sot{Clock::now()};
+
+          handleDownstreamQueueEntry(sot,u64TxSequenceNumber_);
+        }
     }
   else
     {
@@ -1088,11 +1094,12 @@ EMANE::Models::RFPipe::MACLayer::processDownstreamPacket(DownstreamPacket & pkt,
             scheduleTimedEvent(sot,
                                new std::function<bool()>{std::bind(&MACLayer::handleDownstreamQueueEntry,
                                                                    this,
-                                                                   sot)});
+                                                                   sot,
+                                                                   u64TxSequenceNumber_)});
         }
       else
         {
-          handleDownstreamQueueEntry(sot);
+          handleDownstreamQueueEntry(sot,u64TxSequenceNumber_);
         }
     }
 }
@@ -1100,118 +1107,125 @@ EMANE::Models::RFPipe::MACLayer::processDownstreamPacket(DownstreamPacket & pkt,
 
 
 
-bool 
-EMANE::Models::RFPipe::MACLayer::handleDownstreamQueueEntry(TimePoint sot)
+bool
+EMANE::Models::RFPipe::MACLayer::handleDownstreamQueueEntry(TimePoint sot,
+                                                            std::uint64_t u64TxSequenceNumber)
 {
-  // previous end-of-transmission time
-  TimePoint now = Clock::now();
-
-  if(bHasPendingDownstreamQueueEntry_)
+  if(u64TxSequenceNumber == u64TxSequenceNumber_)
     {
-      if(bFlowControlEnable_)
-        {
-          auto status = flowControlManager_.addToken();
+      // previous end-of-transmission time
+      TimePoint now = Clock::now();
 
-          if(!status.second)
+      if(bHasPendingDownstreamQueueEntry_)
+        {
+          if(bFlowControlEnable_)
             {
-              LOGGER_STANDARD_LOGGING(pPlatformService_->logService(),
-                                      ERROR_LEVEL,
-                                      "MACI %03hu %s::%s: failed to add token (tokens:%hu)",
-                                      id_,
-                                      pzLayerName,
-                                      __func__,
-                                      status.first);
+              auto status = flowControlManager_.addToken();
 
+              if(!status.second)
+                {
+                  LOGGER_STANDARD_LOGGING(pPlatformService_->logService(),
+                                          ERROR_LEVEL,
+                                          "MACI %03hu %s::%s: failed to add token (tokens:%hu)",
+                                          id_,
+                                          pzLayerName,
+                                          __func__,
+                                          status.first);
+
+                }
             }
-        }
-      
-      MACHeaderMessage rfpipeMACHeader{pendingDownstreamQueueEntry_.u64DataRatebps_}; 
 
-      Serialization serialization{rfpipeMACHeader.serialize()};
+          MACHeaderMessage rfpipeMACHeader{pendingDownstreamQueueEntry_.u64DataRatebps_};
 
-      auto & pkt = pendingDownstreamQueueEntry_.pkt_;
-      
-      // prepend mac header to outgoing packet
-       pkt.prepend(serialization.c_str(), serialization.size());
+          Serialization serialization{rfpipeMACHeader.serialize()};
 
-       // next prepend the serialization length
-       pkt.prependLengthPrefixFraming(serialization.size());
-       
-       commonLayerStatistics_.processOutbound(pkt, 
-                                              std::chrono::duration_cast<Microseconds>(now - pendingDownstreamQueueEntry_.acquireTime_));
+          auto & pkt = pendingDownstreamQueueEntry_.pkt_;
 
-       /** [pysicallayer-frequencycontrolmessage-snippet] */
-       
-       sendDownstreamPacket(CommonMACHeader(type_, pendingDownstreamQueueEntry_.u64SequenceNumber_), 
-                            pkt,
-                            {Controls::FrequencyControlMessage::create(0,                                   // bandwidth (0 means use phy default)
-                                                                       {{0, pendingDownstreamQueueEntry_.durationMicroseconds_}}), // freq (0 means use phy default)
-                                Controls::TimeStampControlMessage::create(sot)});
-       
-       /** [pysicallayer-frequencycontrolmessage-snippet] */
-      // queue delay
-      Microseconds queueDelayMicroseconds{std::chrono::duration_cast<Microseconds>(now - pendingDownstreamQueueEntry_.acquireTime_)};
-      
-      *pNumDownstreamQueueDelay_ += queueDelayMicroseconds.count();
-      
-      avgDownstreamQueueDelay_.update(queueDelayMicroseconds.count());
-      
-      queueMetricManager_.updateQueueMetric(0,                                      // queue id, (we only have 1 queue)
-                                            downstreamQueue_.getMaxCapacity(),      // queue size
-                                            downstreamQueue_.getCurrentDepth(),     // queue depth
-                                            downstreamQueue_.getNumDiscards(true),  // get queue discards and clear counter
-                                            queueDelayMicroseconds);                // queue delay 
-          
-      neighborMetricManager_.updateNeighborTxMetric(pendingDownstreamQueueEntry_.pkt_.getPacketInfo().getDestination(),
-                                                    pendingDownstreamQueueEntry_.u64DataRatebps_, 
-                                                    now);
-      
+          // prepend mac header to outgoing packet
+          pkt.prepend(serialization.c_str(), serialization.size());
 
-      auto eor = sot + pendingDownstreamQueueEntry_.durationMicroseconds_;
+          // next prepend the serialization length
+          pkt.prependLengthPrefixFraming(serialization.size());
 
-      auto pCallback = new std::function<bool()>{[this]()
-                                                 {
-                                                   std::tie(pendingDownstreamQueueEntry_,
-                                                            bHasPendingDownstreamQueueEntry_) =
-                                                   downstreamQueue_.dequeue();
+          commonLayerStatistics_.processOutbound(pkt,
+                                                 std::chrono::duration_cast<Microseconds>(now - pendingDownstreamQueueEntry_.acquireTime_));
 
-                                                   if(bHasPendingDownstreamQueueEntry_)
+          /** [pysicallayer-frequencycontrolmessage-snippet] */
+
+          sendDownstreamPacket(CommonMACHeader(type_, u64TxSequenceNumber_++),
+                               pkt,
+                               {Controls::FrequencyControlMessage::create(0, // bandwidth (0 means use phy default)
+                                                                          {{0, pendingDownstreamQueueEntry_.durationMicroseconds_}}), // freq (0 means use phy default)
+                                   Controls::TimeStampControlMessage::create(sot)});
+
+          /** [pysicallayer-frequencycontrolmessage-snippet] */
+          // queue delay
+          Microseconds queueDelayMicroseconds{std::chrono::duration_cast<Microseconds>(now - pendingDownstreamQueueEntry_.acquireTime_)};
+
+          *pNumDownstreamQueueDelay_ += queueDelayMicroseconds.count();
+
+          avgDownstreamQueueDelay_.update(queueDelayMicroseconds.count());
+
+          queueMetricManager_.updateQueueMetric(0,                                      // queue id, (we only have 1 queue)
+                                                downstreamQueue_.getMaxCapacity(),      // queue size
+                                                downstreamQueue_.getCurrentDepth(),     // queue depth
+                                                downstreamQueue_.getNumDiscards(true),  // get queue discards and clear counter
+                                                queueDelayMicroseconds);                // queue delay
+
+          neighborMetricManager_.updateNeighborTxMetric(pendingDownstreamQueueEntry_.pkt_.getPacketInfo().getDestination(),
+                                                        pendingDownstreamQueueEntry_.u64DataRatebps_,
+                                                        now);
+
+
+          auto eor = sot + pendingDownstreamQueueEntry_.durationMicroseconds_;
+
+          auto pCallback = new std::function<bool()>{[this]()
                                                      {
-                                                       Microseconds txDelay{delayMicroseconds_ + getJitter()};
+                                                       std::tie(pendingDownstreamQueueEntry_,
+                                                                bHasPendingDownstreamQueueEntry_) =
+                                                       downstreamQueue_.dequeue();
 
-                                                       TimePoint sot{Clock::now() + txDelay};
-                                                       
-                                                       if(txDelay > Microseconds::zero())
+                                                       if(bHasPendingDownstreamQueueEntry_)
                                                          {
-                                                           downstreamQueueTimedEventId_ = 
-                                                             pPlatformService_->timerService().
-                                                             scheduleTimedEvent(sot,
-                                                                                new std::function<bool()>{std::bind(&MACLayer::handleDownstreamQueueEntry,
-                                                                                                                    this,
-                                                                                                                    sot)});
+                                                           Microseconds txDelay{delayMicroseconds_ + getJitter()};
+
+                                                           TimePoint sot{Clock::now() + txDelay};
+
+                                                           if(txDelay > Microseconds::zero())
+                                                             {
+                                                               downstreamQueueTimedEventId_ =
+                                                                 pPlatformService_->timerService().
+                                                                 scheduleTimedEvent(sot,
+                                                                                    new std::function<bool()>{std::bind(&MACLayer::handleDownstreamQueueEntry,
+                                                                                                                        this,
+                                                                                                                        sot,
+                                                                                                                        u64TxSequenceNumber_)});
+                                                             }
+                                                           else
+                                                             {
+                                                               handleDownstreamQueueEntry(sot,u64TxSequenceNumber_);
+                                                             }
                                                          }
-                                                       else
-                                                         {
-                                                           handleDownstreamQueueEntry(sot);
-                                                         }
-                                                     }
 
-                                                   return true;
-                                                 }};
-                                                   
+                                                       return true;
+                                                     }};
 
 
-      if(eor > now)
-        {
-          // wait for end of reception before processing next packet
-          pPlatformService_->timerService().scheduleTimedEvent(eor,pCallback);
-        }
-      else
-        {
-          // we can process now, end of reception has past
-          (*pCallback)();
-              
-          delete pCallback;
+          if(eor > now)
+            {
+              // wait for end of reception before processing next packet
+              pPlatformService_->timerService().scheduleTimedEvent(eor,pCallback);
+            }
+          else
+            {
+              // we can process now, end of reception has past
+              (*pCallback)();
+
+              delete pCallback;
+            }
+
+          // update current end of transmission
+          currentEndOfTransmissionTime_ = eor;
         }
     }
 

--- a/src/models/mac/rfpipe/maclayer.h
+++ b/src/models/mac/rfpipe/maclayer.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2014 - Adjacent Link LLC, Bridgewater, New Jersey
+ * Copyright (c) 2013-2015 - Adjacent Link LLC, Bridgewater, New Jersey
  * Copyright (c) 2008,2009,2010 - DRS CenGen, LLC, Columbia, Maryland
  * All rights reserved.
  *
@@ -184,7 +184,9 @@ namespace EMANE
 
         DownstreamQueueEntry pendingDownstreamQueueEntry_;
 
-        bool handleDownstreamQueueEntry(TimePoint sot);  
+        TimePoint currentEndOfTransmissionTime_;
+
+        bool handleDownstreamQueueEntry(TimePoint sot, std::uint64_t u64TxSequenceNumber);
 
         Microseconds getDurationMicroseconds(size_t lengthInBytes);
 

--- a/src/models/mac/tdma/Makefile.am
+++ b/src/models/mac/tdma/Makefile.am
@@ -12,6 +12,7 @@ libtdmabase_la_CPPFLAGS=             \
  $(libxml2_CFLAGS)
 
 libtdmabase_la_SOURCES =             \
+ aggregationstatuspublisher.cc       \
  basemodel.cc                        \
  basemodelimpl.cc                    \
  basicqueuemanager.cc                \
@@ -29,6 +30,7 @@ BUILT_SOURCES =                      \
  tdmabasemodelmessage.pb.h
 
 EXTRA_DIST=                          \
+ aggregationstatuspublisher.h        \
  basemodelimpl.h                     \
  basemodelmessage.h                  \
  basemodelmessage.inl                \

--- a/src/models/mac/tdma/Makefile.in
+++ b/src/models/mac/tdma/Makefile.in
@@ -122,8 +122,9 @@ am__uninstall_files_from_dir = { \
 am__installdirs = "$(DESTDIR)$(libdir)"
 LTLIBRARIES = $(lib_LTLIBRARIES)
 libtdmabase_la_LIBADD =
-am_libtdmabase_la_OBJECTS = libtdmabase_la-basemodel.lo \
-	libtdmabase_la-basemodelimpl.lo \
+am_libtdmabase_la_OBJECTS =  \
+	libtdmabase_la-aggregationstatuspublisher.lo \
+	libtdmabase_la-basemodel.lo libtdmabase_la-basemodelimpl.lo \
 	libtdmabase_la-basicqueuemanager.lo \
 	libtdmabase_la-packetstatuspublisherimpl.lo \
 	libtdmabase_la-pormanager.lo libtdmabase_la-queue.lo \
@@ -404,6 +405,7 @@ libtdmabase_la_CPPFLAGS = \
  $(libxml2_CFLAGS)
 
 libtdmabase_la_SOURCES = \
+ aggregationstatuspublisher.cc       \
  basemodel.cc                        \
  basemodelimpl.cc                    \
  basicqueuemanager.cc                \
@@ -421,6 +423,7 @@ BUILT_SOURCES = \
  tdmabasemodelmessage.pb.h
 
 EXTRA_DIST = \
+ aggregationstatuspublisher.h        \
  basemodelimpl.h                     \
  basemodelmessage.h                  \
  basemodelmessage.inl                \
@@ -520,6 +523,7 @@ mostlyclean-compile:
 distclean-compile:
 	-rm -f *.tab.c
 
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/libtdmabase_la-aggregationstatuspublisher.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/libtdmabase_la-basemodel.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/libtdmabase_la-basemodelimpl.Plo@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/libtdmabase_la-basicqueuemanager.Plo@am__quote@
@@ -552,6 +556,13 @@ distclean-compile:
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='$<' object='$@' libtool=yes @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(LTCXXCOMPILE) -c -o $@ $<
+
+libtdmabase_la-aggregationstatuspublisher.lo: aggregationstatuspublisher.cc
+@am__fastdepCXX_TRUE@	$(AM_V_CXX)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libtdmabase_la_CPPFLAGS) $(CPPFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS) -MT libtdmabase_la-aggregationstatuspublisher.lo -MD -MP -MF $(DEPDIR)/libtdmabase_la-aggregationstatuspublisher.Tpo -c -o libtdmabase_la-aggregationstatuspublisher.lo `test -f 'aggregationstatuspublisher.cc' || echo '$(srcdir)/'`aggregationstatuspublisher.cc
+@am__fastdepCXX_TRUE@	$(AM_V_at)$(am__mv) $(DEPDIR)/libtdmabase_la-aggregationstatuspublisher.Tpo $(DEPDIR)/libtdmabase_la-aggregationstatuspublisher.Plo
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	$(AM_V_CXX)source='aggregationstatuspublisher.cc' object='libtdmabase_la-aggregationstatuspublisher.lo' libtool=yes @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCXX_FALSE@	DEPDIR=$(DEPDIR) $(CXXDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCXX_FALSE@	$(AM_V_CXX@am__nodep@)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libtdmabase_la_CPPFLAGS) $(CPPFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS) -c -o libtdmabase_la-aggregationstatuspublisher.lo `test -f 'aggregationstatuspublisher.cc' || echo '$(srcdir)/'`aggregationstatuspublisher.cc
 
 libtdmabase_la-basemodel.lo: basemodel.cc
 @am__fastdepCXX_TRUE@	$(AM_V_CXX)$(LIBTOOL) $(AM_V_lt) --tag=CXX $(AM_LIBTOOLFLAGS) $(LIBTOOLFLAGS) --mode=compile $(CXX) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(libtdmabase_la_CPPFLAGS) $(CPPFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS) -MT libtdmabase_la-basemodel.lo -MD -MP -MF $(DEPDIR)/libtdmabase_la-basemodel.Tpo -c -o libtdmabase_la-basemodel.lo `test -f 'basemodel.cc' || echo '$(srcdir)/'`basemodel.cc

--- a/src/models/mac/tdma/aggregationstatuspublisher.cc
+++ b/src/models/mac/tdma/aggregationstatuspublisher.cc
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2015 - Adjacent Link LLC, Bridgewater, New Jersey
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in
+ *   the documentation and/or other materials provided with the
+ *   distribution.
+ * * Neither the name of Adjacent Link LLC nor the names of its
+ *   contributors may be used to endorse or promote products derived
+ *   from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "aggregationstatuspublisher.h"
+
+EMANE::Models::TDMA::AggregationStatusPublisher::AggregationStatusPublisher():
+  pAggregationHistogramTable_{},
+  aggregationHistogram_{}
+{}
+
+void EMANE::Models::TDMA::AggregationStatusPublisher::registerStatistics(StatisticRegistrar & statisticRegistrar)
+{
+  pAggregationHistogramTable_ =
+    statisticRegistrar.registerTable<std::uint64_t>("PacketComponentAggregationHistogram",
+      {"Components","Count"},
+      StatisticProperties::NONE,
+      "Shows a histogram of the number of components contained in transmitted messages.");
+}
+
+void EMANE::Models::TDMA::AggregationStatusPublisher::update(const MessageComponents & components)
+{
+  std::uint64_t u64NumberComponents{components.size()};
+
+  auto iter = aggregationHistogram_.find(u64NumberComponents);
+
+  if(iter == aggregationHistogram_.end())
+    {
+      aggregationHistogram_.insert({u64NumberComponents,1});
+
+      pAggregationHistogramTable_->addRow(u64NumberComponents,
+                                          {Any{u64NumberComponents},
+                                              Any{1L}});
+    }
+  else
+    {
+      ++iter->second;
+
+      pAggregationHistogramTable_->setCell(u64NumberComponents,
+                                           1,
+                                           Any{iter->second});
+    }
+}

--- a/src/models/mac/tdma/aggregationstatuspublisher.h
+++ b/src/models/mac/tdma/aggregationstatuspublisher.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright (c) 2015 - Adjacent Link LLC, Bridgewater, New Jersey
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * * Redistributions of source code must retain the above copyright
+ *   notice, this list of conditions and the following disclaimer.
+ * * Redistributions in binary form must reproduce the above copyright
+ *   notice, this list of conditions and the following disclaimer in
+ *   the documentation and/or other materials provided with the
+ *   distribution.
+ * * Neither the name of Adjacent Link LLC nor the names of its
+ *   contributors may be used to endorse or promote products derived
+ *   from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef EMANEMODELSTDMAAGGREGATIONSTATUSTABLEPUBLISHER_HEADER_
+#define EMANEMODELSTDMAAGGREGATIONSTATUSTABLEPUBLISHER_HEADER_
+
+#include "emane/statisticregistrar.h"
+#include "emane/models/tdma/messagecomponent.h"
+
+#include <map>
+
+namespace EMANE
+{
+  namespace Models
+  {
+    namespace TDMA
+    {
+      /**
+       * @class AggregationStatusPublisher
+       *
+       * @brief Aggregation statistic and statistic table status publisher.
+       */
+      class AggregationStatusPublisher
+      {
+      public:
+        AggregationStatusPublisher();
+
+        void registerStatistics(StatisticRegistrar & registrar);
+
+        void update(const MessageComponents & components);
+
+      private:
+        StatisticTable<uint64_t> * pAggregationHistogramTable_;
+
+        using AggregationHistogram = std::map<uint64_t,std::uint64_t>;
+
+        AggregationHistogram aggregationHistogram_;
+      };
+    }
+  }
+}
+
+#endif // EMANEMODELSTDMAAGGREGATIONSTATUSTABLEPUBLISHER_HEADER_

--- a/src/models/mac/tdma/basemodelimpl.cc
+++ b/src/models/mac/tdma/basemodelimpl.cc
@@ -180,6 +180,8 @@ EMANE::Models::TDMA::BaseModel::Implementation::initialize(Registrar & registrar
 
   neighborMetricManager_.registerStatistics(statisticRegistrar);
 
+  aggregationStatusPublisher_.registerStatistics(statisticRegistrar);
+
   pQueueManager_->setPacketStatusPublisher(&packetStatusPublisher_);
 
   pQueueManager_->initialize(registrar);
@@ -1083,6 +1085,8 @@ void EMANE::Models::TDMA::BaseModel::Implementation::sendDownstreamPacket(double
 
                 }
             }
+
+          aggregationStatusPublisher_.update(components);
 
           BaseModelMessage baseModelMessage{pendingTxSlotInfo_.u64AbsoluteSlotIndex_,
               pendingTxSlotInfo_.u64DataRatebps_,

--- a/src/models/mac/tdma/basemodelimpl.h
+++ b/src/models/mac/tdma/basemodelimpl.h
@@ -43,6 +43,7 @@
 #include "slotstatustablepublisher.h"
 #include "receivemanager.h"
 #include "packetstatuspublisherimpl.h"
+#include "aggregationstatuspublisher.h"
 
 namespace EMANE
 {
@@ -140,6 +141,7 @@ namespace EMANE
         ReceiveManager receiveManager_;
         FlowControlManager flowControlManager_;
         std::uint64_t u64ScheduleIndex_;
+        AggregationStatusPublisher aggregationStatusPublisher_;
 
         void sendDownstreamPacket(double dSlotRemainingRatio);
 

--- a/src/models/mac/tdma/basicqueuemanager.cc
+++ b/src/models/mac/tdma/basicqueuemanager.cc
@@ -270,8 +270,6 @@ size_t EMANE::Models::TDMA::BasicQueueManager::enqueue(std::uint8_t u8QueueIndex
     {
       auto ret = pImpl_->queues_[u8QueueIndex].enqueue(std::move(pkt));
 
-      pImpl_->queueStatusPublisher_.enqueue(u8QueueIndex);
-
       if(ret.second)
         {
           packetsDropped = 1;
@@ -288,6 +286,8 @@ size_t EMANE::Models::TDMA::BasicQueueManager::enqueue(std::uint8_t u8QueueIndex
                                             ret.first->length(),
                                             PacketStatusPublisher::OutboundAction::DROP_OVERFLOW);
         }
+
+      pImpl_->queueStatusPublisher_.enqueue(u8QueueIndex);
     }
 
   return packetsDropped;

--- a/src/models/mac/tdma/queuestatuspublisher.cc
+++ b/src/models/mac/tdma/queuestatuspublisher.cc
@@ -90,6 +90,30 @@ void EMANE::Models::TDMA::QueueStatusPublisher::registerStatistics(StatisticRegi
     }
 
 
+  pHighWaterMarkQueue_[0] =
+    statisticRegistrar.registerNumeric<std::uint64_t>("highWaterMarkQueue0",
+                                                      StatisticProperties::CLEARABLE,
+                                                      "High water mark queue 0");
+
+  pHighWaterMarkQueue_[1] =
+    statisticRegistrar.registerNumeric<std::uint64_t>("highWaterMarkQueue1",
+                                                      StatisticProperties::CLEARABLE,
+                                                      "High water mark queue 1");
+
+  pHighWaterMarkQueue_[2] =
+    statisticRegistrar.registerNumeric<std::uint64_t>("highWaterMarkQueue2",
+                                                      StatisticProperties::CLEARABLE,
+                                                      "High water mark queue 2");
+
+  pHighWaterMarkQueue_[3] =
+    statisticRegistrar.registerNumeric<std::uint64_t>("highWaterMarkQueue3",
+                                                      StatisticProperties::CLEARABLE,
+                                                      "High water mark queue 3");
+
+  pHighWaterMarkQueue_[4] =
+    statisticRegistrar.registerNumeric<std::uint64_t>("highWaterMarkQueue4",
+                                                      StatisticProperties::CLEARABLE,
+                                                      "High water mark queue 4");
 }
 
 void EMANE::Models::TDMA::QueueStatusPublisher::drop(std::uint8_t u8Queue,
@@ -112,6 +136,8 @@ void EMANE::Models::TDMA::QueueStatusPublisher::drop(std::uint8_t u8Queue,
       pQueueStatusTable_->setCell(u8Queue,4,Any{toobig});
       break;
     }
+
+  depthQueueInfo_[u8Queue] -= count;
 }
 
 void EMANE::Models::TDMA::QueueStatusPublisher::dequeue(std::uint8_t u8RequestQueue,
@@ -181,10 +207,21 @@ void EMANE::Models::TDMA::QueueStatusPublisher::dequeue(std::uint8_t u8RequestQu
     pQueueStatusTable_->setCell(u8ActualQueue,9,Any{queue4});
     break;
     }
+
+  depthQueueInfo_[u8ActualQueue] -= packetsCompletedSend;
 }
 
 void EMANE::Models::TDMA::QueueStatusPublisher::enqueue(std::uint8_t u8Queue)
 {
   auto & enqueued = std::get<0>(statusTableInfo_[u8Queue]);
   pQueueStatusTable_->setCell(u8Queue,1,Any{++enqueued});
+
+  ++depthQueueInfo_[u8Queue];
+
+  if(depthQueueInfo_[u8Queue] > highWaterMarkQueueInfo_[u8Queue])
+    {
+      highWaterMarkQueueInfo_[u8Queue] = depthQueueInfo_[u8Queue];
+
+      *pHighWaterMarkQueue_[u8Queue] = highWaterMarkQueueInfo_[u8Queue];
+    }
 }

--- a/src/models/mac/tdma/queuestatuspublisher.h
+++ b/src/models/mac/tdma/queuestatuspublisher.h
@@ -94,6 +94,10 @@ namespace EMANE
         using FragmentHistogram = std::map<std::uint8_t,std::array<std::uint64_t,10>>;
 
         FragmentHistogram fragmentHistogram_;
+
+        std::array<StatisticNumeric<std::uint64_t> *,5> pHighWaterMarkQueue_;
+        std::array<std::uint64_t,5> depthQueueInfo_;
+        std::array<std::uint64_t,5> highWaterMarkQueueInfo_;
       };
     }
   }


### PR DESCRIPTION
Modifications were made to RF Pipe and 802.11abg logic to short circuit timer use for transmission   delay during periods of high downstream traffic. Instead of waiting for the transmit duration timer to fire in order to send the next downstream packet, a check is performed during *processDownstreamPacket()* to see if transmission delay time has passed with timer callback execution still pending. Under this condition, the next downstream packet will be sent, the associated timer callback will perform no operation when executed and a new transmission delay timer will be scheduled.
    
The callback logic that executes after the transmission delay uses the next available downstream sequence number to indicate whether action needs to be performed. In the short circuit case, the callback will see its cached next sequence number no longer matches the actual next sequence number, indicating the associated post transmission delay action already occurred.
    
This modification increases model throughput performance. Mileage will vary based on server CPU resources and the number of cores available to the emulator.

Additional TDMA statistics and a table were added  to provide more insight during performance analysis. Queue statistics were added to indicate the high water mark on all queues:
    
 * highWaterMarkQueue0
 * highWaterMarkQueue1
 * highWaterMarkQueue2
 * highWaterMarkQueue3
 * highWaterMarkQueue4
    
A packet component aggregation histogram table was added to show counts of the number of message components contained in downstream packets (PacketComponentAggregationHistogram).

