### PR TITLE
feature/issue35

### DIFF
--- a/src/libemane/spectrummonitor.cc
+++ b/src/libemane/spectrummonitor.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2014 - Adjacent Link LLC, Bridgewater, New Jersey
+ * Copyright (c) 2013-2015 - Adjacent Link LLC, Bridgewater, New Jersey
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -133,7 +133,7 @@ EMANE::SpectrumMonitor::update(const TimePoint & now,
   // validate txTime in case of time sync issues
   auto validTxTime = txTime;
       
-  if(txTime > now || now - txTime > timeSyncThreshold_)
+  if(txTime > now + timeSyncThreshold_ || now - txTime > timeSyncThreshold_)
     {
       validTxTime = now;
     }


### PR DESCRIPTION
Added logic to SpectrumMonitor time sync check to apply time sync threshold to future time check. Previous logic was converting any future start of transmission (SoT) time to now instead of allowing SoT to be within now + time sync threshold.

Reported-by: Leonid Veytser
See https://github.com/adjacentlink/emane/issues/35