### PR TITLE
Use constexpr specifier for endianness conversion functions

### DIFF
--- a/include/emane/net.h
+++ b/include/emane/net.h
@@ -78,7 +78,7 @@ namespace EMANE
    (((x) & 0X00000000000000FFULL) << 56))
 
 
-  std::uint64_t inline HTONLL(std::uint64_t x)
+  constexpr std::uint64_t HTONLL(std::uint64_t x)
   {
 #if __BYTE_ORDER == __BIG_ENDIAN
     return x;
@@ -89,7 +89,7 @@ namespace EMANE
 #endif
   }
 
-  std::uint64_t inline NTOHLL(std::uint64_t x)
+  constexpr std::uint64_t NTOHLL(std::uint64_t x)
   {
 #if __BYTE_ORDER == __BIG_ENDIAN
     return x;
@@ -100,7 +100,7 @@ namespace EMANE
 #endif
   }
 
-  std::uint32_t inline HTONL(std::uint32_t x)
+  constexpr std::uint32_t HTONL(std::uint32_t x)
   {
 #if __BYTE_ORDER == __BIG_ENDIAN
     return x;
@@ -111,7 +111,7 @@ namespace EMANE
 #endif
   }
 
-  std::uint32_t inline NTOHL(std::uint32_t x)
+  constexpr std::uint32_t NTOHL(std::uint32_t x)
   {
 #if __BYTE_ORDER == __BIG_ENDIAN
     return x;
@@ -122,7 +122,7 @@ namespace EMANE
 #endif
   }
 
-  std::uint16_t inline HTONS(std::uint16_t x)
+  constexpr std::uint16_t HTONS(std::uint16_t x)
   {
 #if __BYTE_ORDER == __BIG_ENDIAN
     return x;
@@ -133,7 +133,7 @@ namespace EMANE
 #endif
   }
 
-  std::uint16_t inline NTOHS(std::uint16_t x)
+  constexpr std::uint16_t NTOHS(std::uint16_t x)
   {
 #if __BYTE_ORDER == __BIG_ENDIAN
     return x;


### PR DESCRIPTION
This permits values such as EMANE::HTONS(Utils::ETH_P_IPV4) to be computed at compile-time, which is already possible when using the equivalent preprocessor definitions in glibc. This is required in order to use such value in enums, as an example. Remove the inline specifier, since constexpr functions are implicitly inline.

Signed-off-by: David Ward <david.ward@ll.mit.edu>