### PR TITLE
Add missing get() wrapper function in DownstreamPacket class

### DIFF
--- a/include/emane/downstreampacket.h
+++ b/include/emane/downstreampacket.h
@@ -117,6 +117,13 @@ namespace EMANE
     Utils::VectorIO getVectorIO() const;
 
     /**
+     * Gets a pointer to the internal buffer holding the message
+     *
+     * @return Pointer to message or @c 0 if there is no data
+     */
+    const void * get() const;
+
+    /**
      * Gets the overall packet length which is a summation of all the
      * vectored IO segments.
      *

--- a/src/libemane/downstreampacket.cc
+++ b/src/libemane/downstreampacket.cc
@@ -194,6 +194,11 @@ EMANE::Utils::VectorIO EMANE::DownstreamPacket::getVectorIO() const
   return pImpl_->getVectorIO();
 }
 
+const void * EMANE::DownstreamPacket::get() const
+{
+  return pImpl_->get();
+}
+  
 size_t EMANE::DownstreamPacket::length() const
 {
   return pImpl_->length();


### PR DESCRIPTION
An EMANE::DownstreamPacket::get() function was available prior to version 0.9.x, which returned a pointer to the packet data (first combining packet segments if necessary). It has been moved to the EMANE::DownstreamPacket::Implementation class, but there is not a wrapper function to call it from EMANE::DownstreamPacket. This is useful in situations where the MAC layer does not simply prepend headers to downstream packets, but consumes them and creates its own downstream packets instead.

Signed-off-by: David Ward <david.ward@ll.mit.edu>