### PR TITLE
Add transmit power level to frequency segments. The addition

### DIFF
--- a/include/emane/frequencysegment.h
+++ b/include/emane/frequencysegment.h
@@ -55,12 +55,25 @@ namespace EMANE
      * @param u64FrequencyHz Frequency in Hz
      * @param durationMicroseconds Segment duration in microseconds
      * @param offsetMicroseconds Segment offset relative to the start not the previous segment
-     * @param dRxPowerdBm Receive power of the segment in dBm (upstream only)
      */
     FrequencySegment(std::uint64_t u64FrequencyHz,
                      const Microseconds & durationMicroseconds,
-                     const Microseconds & offsetMicroseconds = Microseconds::zero(),
-                     double dRxPowerdBm = 0);
+                     const Microseconds & offsetMicroseconds = Microseconds::zero());
+
+
+    /**
+     * Create a FrequencySegment instance
+     *
+     * @param u64FrequencyHz Frequency in Hz
+     * @param durationMicroseconds Segment duration in microseconds
+     * @param offsetMicroseconds Segment offset relative to the start not the previous segment
+     * @param dPowerdBm Receive power of the segment in dBm (upstream) or transmit power of
+     *        segment in dBm (downstream)
+     */
+    FrequencySegment(std::uint64_t u64FrequencyHz,
+                     double dPowerdBm,
+                     const Microseconds & durationMicroseconds,
+                     const Microseconds & offsetMicroseconds = Microseconds::zero());
 
     /**
      * Create a FrequencySegment from another instance
@@ -104,12 +117,20 @@ namespace EMANE
      * @return receive power
      */
     double getRxPowerdBm() const;
+
+    /**
+     * Gets the power of the segment in dBm if present
+     *
+     * @return pair receive power and flag that is true if power specified
+     */
+    std::pair<double,bool> getPowerdBm() const;
     
   private:
     std::uint64_t u64FrequencyHz_;
     Microseconds durationMicroseconds_;
     Microseconds offsetMicroseconds_;
-    double dRxPowerdBm_;
+    double dPowerdBm_;
+    bool bHasPower_;
   };
   
   using FrequencySegments = std::list<FrequencySegment>;

--- a/include/emane/frequencysegment.inl
+++ b/include/emane/frequencysegment.inl
@@ -32,22 +32,33 @@
 
 inline
 EMANE::FrequencySegment::FrequencySegment(std::uint64_t u64FrequencyHz,
+                                          double dPowerdBm,
                                           const Microseconds & durationMicroseconds,
-                                          const Microseconds & offsetMicroseconds,
-                                          double dRxPowerdBm):
+                                          const Microseconds & offsetMicroseconds):
   u64FrequencyHz_{u64FrequencyHz},
   durationMicroseconds_{durationMicroseconds},
   offsetMicroseconds_{offsetMicroseconds},
-  dRxPowerdBm_{dRxPowerdBm}{}
+  dPowerdBm_{dPowerdBm},
+  bHasPower_{true}{}
+
+inline
+EMANE::FrequencySegment::FrequencySegment(std::uint64_t u64FrequencyHz,
+                                          const Microseconds & durationMicroseconds,
+                                          const Microseconds & offsetMicroseconds):
+  u64FrequencyHz_{u64FrequencyHz},
+  durationMicroseconds_{durationMicroseconds},
+  offsetMicroseconds_{offsetMicroseconds},
+  dPowerdBm_{},
+  bHasPower_{false}{}
 
 inline
 EMANE::FrequencySegment::FrequencySegment(const FrequencySegment & rhs,
-                                          double dRxPowerdBm):
+                                          double dPowerdBm):
   u64FrequencyHz_{rhs.u64FrequencyHz_},
   durationMicroseconds_{rhs.durationMicroseconds_},
   offsetMicroseconds_{rhs.offsetMicroseconds_},
-  dRxPowerdBm_{dRxPowerdBm}{}
-
+  dPowerdBm_{dPowerdBm},
+  bHasPower_{true}{}
 
 inline
 std::uint64_t EMANE::FrequencySegment::getFrequencyHz() const
@@ -70,5 +81,11 @@ const EMANE::Microseconds & EMANE::FrequencySegment::getDuration() const
 inline
 double EMANE::FrequencySegment::getRxPowerdBm() const
 {
-  return dRxPowerdBm_;
+  return dPowerdBm_;
+}
+
+inline
+std::pair<double,bool> EMANE::FrequencySegment::getPowerdBm() const
+{
+  return {dPowerdBm_,bHasPower_};
 }

--- a/src/libemane/commonphyheader.proto
+++ b/src/libemane/commonphyheader.proto
@@ -47,6 +47,7 @@ message CommonPHYHeader
     required uint64 frequencyHz = 1;
     required uint64 offsetMicroseconds = 2;
     required uint64 durationMicroseconds = 3;
+    optional double powerdBm = 4;
   }
   
   required uint32 registrationId = 1;

--- a/src/libemane/frameworkphy.cc
+++ b/src/libemane/frameworkphy.cc
@@ -739,9 +739,19 @@ void EMANE::FrameworkPHY::processDownstreamPacket(DownstreamPacket & pkt,
                 // by using 0 Hz.
                 if(segment.getFrequencyHz() == 0)
                   {
-                    frequencySegments.push_back({u64TxFrequencyHz_,       // use our frequency
-                          segment.getDuration(), // duration
-                          segment.getOffset()}); // offset
+                    if(segment.getPowerdBm().second)
+                      {
+                        frequencySegments.push_back({u64TxFrequencyHz_,       // use our frequency
+                              segment.getPowerdBm().first,
+                              segment.getDuration(), // duration
+                              segment.getOffset()}); // offset
+                      }
+                    else
+                      {
+                        frequencySegments.push_back({u64TxFrequencyHz_,       // use our frequency
+                              segment.getDuration(), // duration
+                              segment.getOffset()}); // offset
+                      }
                   }
                 else
                   {
@@ -977,7 +987,11 @@ void EMANE::FrameworkPHY::processUpstreamPacket_i(const TimePoint & now,
                   // sum up the rx power for each segment
                   for(const auto & dPathlossdB : pathlossInfo.first)
                     {
-                      double powerdBm{transmitter.getPowerdBm() +
+                      auto optionalSegmentPowerdBm = freqIter->getPowerdBm();
+
+                      double powerdBm{(optionalSegmentPowerdBm.second ?
+                                       optionalSegmentPowerdBm.first :
+                                       transmitter.getPowerdBm()) +
                           gainInfodBi.first -
                           dPathlossdB};
                       

--- a/src/libemane/spectrummonitor.cc
+++ b/src/libemane/spectrummonitor.cc
@@ -213,9 +213,9 @@ EMANE::SpectrumMonitor::update(const TimePoint & now,
                     std::min(minSoR,validTxTime + validOffset + validPropagation);
 
                   reportableFrequencySegments.push_back({segment.getFrequencyHz(),
+                        Utils::MILLIWATT_TO_DB(rxPowersMilliWatt[i]),
                         validDuration,
-                        validOffset,
-                        Utils::MILLIWATT_TO_DB(rxPowersMilliWatt[i])});
+                        validOffset});
                 }
 
               ++i;
@@ -389,9 +389,9 @@ EMANE::SpectrumMonitor::update(const TimePoint & now,
                   minSoR = std::min(minSoR,startOfReception);
               
                   reportableFrequencySegments.push_back({segment.getFrequencyHz(),
+                        Utils::MILLIWATT_TO_DB(rxPowersMilliWatt[i]),
                         validDuration,
-                        validOffset,
-                        Utils::MILLIWATT_TO_DB(rxPowersMilliWatt[i])});
+                        validOffset});
                 }
             }
 

--- a/test/testcases/phyupstreamscenario001/testcase-target.txt
+++ b/test/testcases/phyupstreamscenario001/testcase-target.txt
@@ -46,7 +46,7 @@
 [2]   duration: 200
 [2]   offset: 0
 [2]   src: 2
-[2]   power: 0.000000
+[2]   transmitter power: 0.000000
 
 [2]  Packet dropped
 
@@ -72,7 +72,7 @@
 [4]   duration: 200
 [4]   offset: 0
 [4]   src: 2
-[4]   power: 0.000000
+[4]   transmitter power: 0.000000
 
 [4]  Packet dropped
 
@@ -94,7 +94,7 @@
 [5]   duration: 200
 [5]   offset: 0
 [5]   src: 4
-[5]   power: 3.000000
+[5]   transmitter power: 3.000000
 
 [5]  Packet dropped
 
@@ -117,7 +117,7 @@
 [6]   duration: 200
 [6]   offset: 0
 [6]   src: 2
-[6]   power: 3.000000
+[6]   transmitter power: 3.000000
 
 [6]  Packet forwarded to next layer
 
@@ -150,7 +150,7 @@ Processing upstream packet...
 [8]   duration: 200
 [8]   offset: 0
 [8]   src: 2
-[8]   power: 5.000000
+[8]   transmitter power: 5.000000
 
 [8]  Packet forwarded to next layer
 
@@ -182,7 +182,7 @@ Processing upstream packet...
 [10]   duration: 400
 [10]   offset: 0
 [10]   src: 2
-[10]   power: 5.000000
+[10]   transmitter power: 5.000000
 
 [10]  Packet forwarded to next layer
 
@@ -212,7 +212,7 @@ Processing upstream packet...
 [11]   duration: 400
 [11]   offset: 0
 [11]   src: 3
-[11]   power: 0.000000
+[11]   transmitter power: 0.000000
 
 [11]  Packet dropped
 
@@ -239,7 +239,7 @@ Processing upstream packet...
 [12]   duration: 100
 [12]   offset: 120
 [12]   src: 2
-[12]   power: 5.000000
+[12]   transmitter power: 5.000000
 
 [12]  Packet forwarded to next layer
 

--- a/test/testcases/phyupstreamscenario002/testcase-target.txt
+++ b/test/testcases/phyupstreamscenario002/testcase-target.txt
@@ -50,7 +50,7 @@
 [3]   duration: 200
 [3]   offset: 0
 [3]   src: 2
-[3]   power: 0.000000
+[3]   transmitter power: 0.000000
 
 [3]  Packet dropped
 
@@ -81,7 +81,7 @@
 [5]   duration: 100
 [5]   offset: 400
 [5]   src: 2
-[5]   power: 5.000000
+[5]   transmitter power: 5.000000
 
 [5]  Packet forwarded to next layer
 
@@ -119,7 +119,7 @@ Processing upstream packet...
 [7]   duration: 100
 [7]   offset: 400
 [7]   src: 2
-[7]   power: 5.000000
+[7]   transmitter power: 5.000000
 
 [7]  Packet forwarded to next layer
 

--- a/test/testcases/phyupstreamscenario003/testcase-target.txt
+++ b/test/testcases/phyupstreamscenario003/testcase-target.txt
@@ -50,7 +50,7 @@
 [3]   duration: 200
 [3]   offset: 0
 [3]   src: 2
-[3]   power: 0.000000
+[3]   transmitter power: 0.000000
 
 [3]  Packet dropped
 
@@ -75,7 +75,7 @@
 [5]   duration: 200
 [5]   offset: 0
 [5]   src: 2
-[5]   power: 0.000000
+[5]   transmitter power: 0.000000
 
 [5]  Packet dropped
 
@@ -100,7 +100,7 @@
 [7]   duration: 200
 [7]   offset: 0
 [7]   src: 2
-[7]   power: 0.000000
+[7]   transmitter power: 0.000000
 
 [7]  Packet dropped
 
@@ -127,7 +127,7 @@
 [9]   duration: 200
 [9]   offset: 0
 [9]   src: 4
-[9]   power: 0.000000
+[9]   transmitter power: 0.000000
 
 [9]  Packet dropped
 
@@ -155,7 +155,7 @@
 [12]   duration: 200
 [12]   offset: 100
 [12]   src: 4
-[12]   power: 2.000000
+[12]   transmitter power: 2.000000
 
 [12]  Packet forwarded to next layer
 
@@ -194,9 +194,9 @@ Processing upstream packet...
 [14]   duration: 100
 [14]   offset: 200
 [14]   src: 2
-[14]   power: 0.000000
+[14]   transmitter power: 0.000000
 [14]   src: 3
-[14]   power: 5.000000
+[14]   transmitter power: 5.000000
 
 [14]  Packet dropped
 
@@ -219,7 +219,7 @@ Processing upstream packet...
 [15]   duration: 500
 [15]   offset: 0
 [15]   src: 4
-[15]   power: 12.000000
+[15]   transmitter power: 12.000000
 
 [15]  Packet forwarded to next layer
 
@@ -260,7 +260,7 @@ Processing upstream packet...
 [17]   duration: 500
 [17]   offset: 0
 [17]   src: 4
-[17]   power: 12.000000
+[17]   transmitter power: 12.000000
 
 [17]  Packet forwarded to next layer
 
@@ -290,7 +290,7 @@ Processing upstream packet...
 [18]   duration: 400
 [18]   offset: 0
 [18]   src: 2
-[18]   power: 0.000000
+[18]   transmitter power: 0.000000
 
 [18]  Packet dropped
 
@@ -313,7 +313,7 @@ Processing upstream packet...
 [19]   duration: 410
 [19]   offset: 100
 [19]   src: 3
-[19]   power: 5.000000
+[19]   transmitter power: 5.000000
 
 [19]  Packet dropped
 

--- a/test/testcases/phyupstreamscenario004/testcase-target.txt
+++ b/test/testcases/phyupstreamscenario004/testcase-target.txt
@@ -50,7 +50,7 @@
 [3]   duration: 200
 [3]   offset: 0
 [3]   src: 2
-[3]   power: 0.000000
+[3]   transmitter power: 0.000000
 
 [3]  Packet dropped
 
@@ -75,7 +75,7 @@
 [5]   duration: 200
 [5]   offset: 0
 [5]   src: 2
-[5]   power: 0.000000
+[5]   transmitter power: 0.000000
 
 [5]  Packet dropped
 
@@ -100,7 +100,7 @@
 [7]   duration: 200
 [7]   offset: 0
 [7]   src: 2
-[7]   power: 0.000000
+[7]   transmitter power: 0.000000
 
 [7]  Packet dropped
 
@@ -127,7 +127,7 @@
 [9]   duration: 200
 [9]   offset: 0
 [9]   src: 4
-[9]   power: 0.000000
+[9]   transmitter power: 0.000000
 
 [9]  Packet dropped
 
@@ -155,7 +155,7 @@
 [12]   duration: 200
 [12]   offset: 100
 [12]   src: 4
-[12]   power: 2.000000
+[12]   transmitter power: 2.000000
 
 [12]  Packet forwarded to next layer
 
@@ -193,9 +193,9 @@ Processing upstream packet...
 [14]   duration: 100
 [14]   offset: 200
 [14]   src: 2
-[14]   power: 0.000000
+[14]   transmitter power: 0.000000
 [14]   src: 3
-[14]   power: 5.000000
+[14]   transmitter power: 5.000000
 
 [14]  Packet dropped
 
@@ -218,7 +218,7 @@ Processing upstream packet...
 [15]   duration: 500
 [15]   offset: 0
 [15]   src: 4
-[15]   power: 12.000000
+[15]   transmitter power: 12.000000
 
 [15]  Packet forwarded to next layer
 
@@ -258,7 +258,7 @@ Processing upstream packet...
 [17]   duration: 200
 [17]   offset: 100
 [17]   src: 4
-[17]   power: 2.000000
+[17]   transmitter power: 2.000000
 
 [17]  Packet forwarded to next layer
 
@@ -288,7 +288,7 @@ Processing upstream packet...
 [18]   duration: 200
 [18]   offset: 300075
 [18]   src: 4
-[18]   power: 2.000000
+[18]   transmitter power: 2.000000
 
 [18]  Packet forwarded to next layer
 

--- a/test/testcases/phyupstreamscenario005/testcase-target.txt
+++ b/test/testcases/phyupstreamscenario005/testcase-target.txt
@@ -60,7 +60,7 @@
 [6]   duration: 200
 [6]   offset: 100
 [6]   src: 4
-[6]   power: 2.000000
+[6]   transmitter power: 2.000000
 
 [6]  Packet forwarded to next layer
 
@@ -113,7 +113,7 @@ Processing upstream packet...
 [10]   duration: 200
 [10]   offset: 100
 [10]   src: 4
-[10]   power: 2.000000
+[10]   transmitter power: 2.000000
 
 [10]  Packet forwarded to next layer
 
@@ -143,7 +143,7 @@ Processing upstream packet...
 [11]   duration: 200
 [11]   offset: 100
 [11]   src: 4
-[11]   power: 2.000000
+[11]   transmitter power: 2.000000
 
 [11]  Packet forwarded to next layer
 
@@ -199,9 +199,9 @@ Processing upstream packet...
 [16]   duration: 100
 [16]   offset: 200
 [16]   src: 2
-[16]   power: 0.000000
+[16]   transmitter power: 0.000000
 [16]   src: 3
-[16]   power: 5.000000
+[16]   transmitter power: 5.000000
 
 [16]  Packet dropped
 
@@ -223,7 +223,7 @@ Processing upstream packet...
 [17]   duration: 500
 [17]   offset: 0
 [17]   src: 4
-[17]   power: 12.000000
+[17]   transmitter power: 12.000000
 
 [17]  Packet forwarded to next layer
 
@@ -264,9 +264,9 @@ Processing upstream packet...
 [19]   duration: 100
 [19]   offset: 200
 [19]   src: 2
-[19]   power: 0.000000
+[19]   transmitter power: 0.000000
 [19]   src: 3
-[19]   power: 5.000000
+[19]   transmitter power: 5.000000
 
 [19]  Packet dropped
 
@@ -292,7 +292,7 @@ Processing upstream packet...
 [21]   duration: 500
 [21]   offset: 0
 [21]   src: 4
-[21]   power: 12.000000
+[21]   transmitter power: 12.000000
 
 [21]  Packet forwarded to next layer
 


### PR DESCRIPTION
permits each frequency segment to be transmitted at a different
power. When specified, the frequency segment power level
takes precedent over the transmitter power levels specified
in the transmitter control messages.

The testcase text files are updated to agree with modified logs.
