### PR TITLE
feature/issue45

### DIFF
--- a/include/emane/utils/parameterconvert.inl
+++ b/include/emane/utils/parameterconvert.inl
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 - Adjacent Link LLC, Bridgewater, New Jersey
+ * Copyright (c) 2015-2016 - Adjacent Link LLC, Bridgewater, New Jersey
  * Copyright (c) 2009,2012 - DRS CenGen, LLC, Columbia, Maryland
  * All rights reserved.
  *
@@ -63,6 +63,14 @@ namespace
 
     if(u8PowerOf10 != 0)
       {
+        // strip any leading whitespace
+        std::string::size_type notWhiteSpace{sTmpParameter.find_first_not_of(" \t")};
+
+        if(notWhiteSpace != std::string::npos)
+          {
+            sTmpParameter = sTmpParameter.substr(notWhiteSpace,std::string::npos);
+          }
+
         // location of decimal point, if exists
         std::string::size_type indexPoint =  sTmpParameter.find(".",0);
 
@@ -74,8 +82,7 @@ namespace
             if(numberOfDigitsAfterPoint > u8PowerOf10)
               {
                 // need to move the decimal point, enough digits are present
-                sTmpParameter.insert(sTmpParameter.size() - (numberOfDigitsAfterPoint - u8PowerOf10),
-                                     ".");
+                sTmpParameter.insert(indexPoint + u8PowerOf10,".");
               }
             else
               {
@@ -90,6 +97,22 @@ namespace
           {
             // need to append 0s
             sTmpParameter.append(u8PowerOf10,'0');
+          }
+
+        // strip any leading zeros but be mindful of sign
+        std::string sSign{};
+
+        if(sTmpParameter.front() == '+' ||
+           sTmpParameter.front() == '-')
+          {
+            sSign = sTmpParameter.front();
+          }
+
+        std::string::size_type not0Index{sTmpParameter.find_first_not_of("0",sSign.size())};
+
+        if(not0Index != sSign.size())
+          {
+            sTmpParameter = sSign + sTmpParameter.substr(not0Index,std::string::npos);
           }
       }
 


### PR DESCRIPTION
An issue occurred when using floating point representation with K, M
or G SI unit values for integer configuration items when the result
after applying the appropriate power of 10 contained one or more
leading 0s.

A leading 0 caused the result to be treated as an octal value. If the
parameter value only contained values in the set of allowable octal
characters, the conversion would succeed but as base 8. If the value
contained digits outside the octal set (e.g. 0.9G), conversion would
fail with a not allowed character exception description.

Functionality was added to remove any leading zeros after SI unit
application minding the possibility of sign inclusion and/or leading
white space. This effectively results in all integer values with SI
units being interpreted as base 10.

Reported-by: bebopagogo <https://github.com/bebopagogo>

See https://github.com/adjacentlink/emane/issues/45