### PR TITLE
autogen.sh: Do not use '--force' flag when calling autoreconf

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -79,5 +79,5 @@ then
     find . -name 'Makefile.in' -delete
     
 else
-    autoreconf --force --install
+    autoreconf --install
 fi


### PR DESCRIPTION
Fixes: #61