### PR TITLE
feature/issue66

### DIFF
--- a/src/emanesh/emanesh/controlportclient.py
+++ b/src/emanesh/emanesh/controlportclient.py
@@ -164,6 +164,7 @@ class ControlPortClient:
     def stop(self):
         os.write(self._write,"\n")
         self._thread.join()
+        self._sock.close()
 
     def getManifest(self):
         request = remotecontrolportapi_pb2.Request()

--- a/src/libemane/controlportservice.cc
+++ b/src/libemane/controlportservice.cc
@@ -156,6 +156,7 @@ void EMANE::ControlPort::Service::process()
               // process the session data
               if(iter->second->process(iter->first))
                 {
+                  ::close(iter->first);
                   sessionMap.erase(iter++);
                 }
               else
@@ -173,6 +174,5 @@ void EMANE::ControlPort::Service::process()
   for(const auto & entry : sessionMap)
     {
       ::close(entry.first);
-      //delete entry.second;
     }
 }


### PR DESCRIPTION
Added logic to ControlPortService to close a session socket on a non-zero return from ControlPortSession::process(). Previous logic was only removing the session from the active session map.

Added emanesh.ControlPortClient socket close on stop().
