### PR TITLE
feature/otafragsupport

### DIFF
--- a/SPONSOR
+++ b/SPONSOR
@@ -12,6 +12,8 @@
  MIT Lincoln Laboratory - TDMA radio model
  https://github.com/adjacentlink/emane/wiki/TDMA-Model
 
+ MIT Lincoln Laboratory - OTA message fragmentation support and
+ external transport TCP connection support.
 
  For more information on sponsoring EMANE features contact us at
  emane-info at adjacentlink dot com.

--- a/scripts/emanegentransportxml
+++ b/scripts/emanegentransportxml
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 #
-# Copyright (c) 2014 - Adjacent Link LLC, Bridgewater, New Jersey
+# Copyright (c) 2014,2017 - Adjacent Link LLC, Bridgewater, New Jersey
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -41,21 +41,21 @@ usage = "%prog [OPTION].. PLATFORMXML..."
 
 optionParser =  OptionParser(usage=usage)
 
-optionParser.add_option("-v", 
+optionParser.add_option("-v",
                         "--verbose",
                         action="store_true",
                         dest="verbose",
                         help="Verbose output mode")
 
-optionParser.add_option("", 
+optionParser.add_option("",
                         "--dtd",
                         action="store",
                         type="string",
                         dest="dtd",
                         default='file:///usr/share/emane/dtd/transportdaemon.dtd',
-                        help="Transport Daemon XML DTD [default: %default]")  
+                        help="Transport Daemon XML DTD [default: %default]")
 
-optionParser.add_option("-o", 
+optionParser.add_option("-o",
                         "--outpath",
                         action="store",
                         type="string",
@@ -103,27 +103,32 @@ try:
 
             if nemTransportLocation == "internal":
                 continue
-            
+
             if nemId not in instances:
                 instances[nemId] = {}
 
             platformendpoint = nem.find("param/[@name='platformendpoint']")
             transportendpoint = nem.find("param/[@name='transportendpoint']")
+            protocol = nem.find("param/[@name='protocol']")
 
             if platformendpoint is None:
                 print >>sys.stderr, "error %s:" % platform," missing 'platformendpoint' for NEM",nemId
-                exit(1) 
+                exit(1)
 
             if transportendpoint is None:
                 print >>sys.stderr, "error %s:" % platform," missing 'transportendpoint' for NEM",nemId
-                exit(1) 
-            
+                exit(1)
+
+
             # store platform and transport endpoints
             metas[nemId] = {
                 'platformendpoint' : platformendpoint.get('value'),
                 'transportendpoint' : transportendpoint.get('value')
             }
-            
+
+            if protocol is not None:
+                metas[nemId]['protocol'] = protocol.get('value')
+
             # load nem XML
             try:
                 if options.verbose:
@@ -138,7 +143,7 @@ try:
                         metas[nemId]['definition'] = transportDefinition
                     elif metas[nemId]['definition'] != transportDefinition:
                         print >>sys.stderr, "error %s:" % nemDefinition," inconsistent transport selected for NEM",nemId
-                        exit(1) 
+                        exit(1)
 
                     # load transport XML
                     try:
@@ -155,14 +160,14 @@ try:
                         for paramlist in transportTree.xpath('/transport/paramlist'):
 
                             instances[nemId][paramlist.get('name')] = []
-                            
+
                             for item in paramlist.xpath('item'):
                                 instances[nemId][paramlist.get('name')].append(item.get('value'))
 
                     except etree.XMLSyntaxError, exp:
                         print >>sys.stderr, "error %s:" % transportDefinition,exp
-                        exit(1)        
-                    
+                        exit(1)
+
                     # process nem XML parameters
                     for param in nemTree.xpath('/nem/transport/param'):
                         instances[nemId][param.get('name')] = [param.get('value')]
@@ -171,7 +176,7 @@ try:
                     for paramlist in nemTree.xpath('/nem/transport/paramlist'):
 
                         instances[nemId][paramlist.get('name')] = []
-                            
+
                         for item in paramlist.xpath('item'):
                             instances[nemId][paramlist.get('name')].append(item.get('value'))
 
@@ -188,7 +193,7 @@ try:
                 transportDefinition = transport.get('definition')
 
                 group = transport.get("group")
-                
+
                 if group is None:
                     group = str(nemId)
 
@@ -196,7 +201,7 @@ try:
                     metas[nemId]['definition'] = transportDefinition
                 elif metas[nemId]['definition'] != transportDefinition:
                     print >>sys.stderr, "error %s:" % platform," inconsistent transport selected for NEM",nemId
-                    exit(1) 
+                    exit(1)
 
                 # process platform XML nem element transport parameters
                 for param in transport.xpath('param'):
@@ -204,9 +209,9 @@ try:
 
                 # process nem XML parameter lists
                 for paramlist in transport.xpath('paramlist'):
-                    
+
                     instances[nemId][paramlist.get('name')] = []
-                            
+
                     for item in paramlist.xpath('item'):
                         instances[nemId][paramlist.get('name')].append(item.get('value'))
 
@@ -215,12 +220,12 @@ try:
 
             # add the nem to a group
             groups[group].append(nemId)
-                    
+
 
 except IOError,exp:
     print >>sys.stderr, "error:",exp
     exit(1)
-    
+
 # create the transport daemon files
 for members in sorted(groups.values()):
     output="transportdaemon%d.xml" % min(members)
@@ -242,17 +247,25 @@ for members in sorted(groups.values()):
                          name='transportendpoint',
                          value=metas[nemId]['transportendpoint'])
 
-        transportElement = etree.SubElement(instanceElement,'transport', definition=metas[nemId]['definition'])
+        if 'protocol' in metas[nemId]:
+            etree.SubElement(instanceElement,
+                             'param',
+                             name='protocol',
+                             value=metas[nemId]['protocol'])
+
+        transportElement = etree.SubElement(instanceElement,
+                                            'transport',
+                                            definition=metas[nemId]['definition'])
 
 
         for name,value in params.items():
             if len(value) == 1:
                 etree.SubElement(transportElement,'param', name=name,value=value[0])
             else:
-                paramlist = etree.SubElement(transportElement,'paramlist', name=name) 
+                paramlist = etree.SubElement(transportElement,'paramlist', name=name)
 
                 for item in value:
-                    etree.SubElement(paramlist,'item', value=item) 
+                    etree.SubElement(paramlist,'item', value=item)
 
 
     target = "transportdaemon%d.xml" % min(members)
@@ -269,9 +282,9 @@ for members in sorted(groups.values()):
 
         if options.verbose:
             print "generating XML:",target
-        
+
         output=open(os.path.join(options.outpath,target),'w')
-        
+
         print >>output,xml
 
         output.close()
@@ -280,6 +293,3 @@ for members in sorted(groups.values()):
         print >>sys.stderr, "error %s:" % target, "unable to validate target xml"
         print >>sys.stderr, exp
         exit(1)
-
-
-

--- a/src/libemane/boundarymessagemanager.cc
+++ b/src/libemane/boundarymessagemanager.cc
@@ -260,7 +260,7 @@ void EMANE::BoundaryMessageManager::sendControlMessage(const ControlMessages & m
   memset(&header,0,sizeof(header));
 
   header.u16Id_ =  NETADAPTER_CTRL_MSG;
-  header.u32Length_ = sizeof(header) + controlMessageSerializer.getLength() + 2;
+  header.u32Length_ = sizeof(header) + controlMessageSerializer.getLength() + 4;
 
   NetAdapterHeaderToNet(&header);
 

--- a/src/libemane/boundarymessagemanager.cc
+++ b/src/libemane/boundarymessagemanager.cc
@@ -1,6 +1,5 @@
 /*
- * Copyright (c) 2013-2016 - Adjacent Link LLC, Bridgewater, New
- * Jersey
+ * Copyright (c) 2013-2017 - Adjacent Link LLC, Bridgewater, New Jersey
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -45,28 +44,40 @@
 #include <iomanip>
 #include <algorithm>
 #include <cstring>
+#include <sys/socket.h>
+#include <unistd.h>
 
 EMANE::BoundaryMessageManager::BoundaryMessageManager(NEMId id):
   id_{id},
-  bOpen_{}{}
+  bOpen_{},
+  iSockFd_{-1},
+  iSessionSockFd_{-1},
+  bConnected_{}{}
+
 
 EMANE::BoundaryMessageManager::~BoundaryMessageManager()
 {
   if(thread_.joinable())
-     {
-       close();
-     }
+    {
+      close();
+    }
 }
 
 void EMANE::BoundaryMessageManager::open(const INETAddr & localAddress,
-                                         const INETAddr & remoteAddress)
+                                         const INETAddr & remoteAddress,
+                                         Protocol protocol)
 {
   localAddress_   = localAddress;
   remoteAddress_  = remoteAddress;
+  protocol_ = protocol;
 
   try
     {
-      udp_.open(localAddress_,true);
+      if(protocol_ == Protocol::PROTOCOL_UDP)
+        {
+          udp_.open(localAddress_,true);
+        }
+      // note: Protocol::PROTOCOL_TCP_* sockets open in thread
     }
   catch(...)
     {
@@ -92,23 +103,46 @@ void EMANE::BoundaryMessageManager::open(const INETAddr & localAddress,
       throw BoundaryMessageManagerException(sstream.str());
     }
 
-  thread_ = std::thread{&BoundaryMessageManager::processNetworkMessage,this};
+  if(protocol_ == Protocol::PROTOCOL_UDP)
+    {
+      thread_ = std::thread{&BoundaryMessageManager::processNetworkMessageUDP,this};
+    }
+  else
+    {
+      thread_ = std::thread{&BoundaryMessageManager::processNetworkMessageTCP,this};
+    }
 
   bOpen_ = true;
 }
 
 void EMANE::BoundaryMessageManager::close()
 {
-  if(thread_.joinable())
+  if(bOpen_)
     {
-      ThreadUtils::cancel(thread_);
+      if(thread_.joinable())
+        {
+          ThreadUtils::cancel(thread_);
 
-      thread_.join();
+          thread_.join();
+        }
+
+      if(protocol_ == Protocol::PROTOCOL_UDP)
+        {
+          udp_.close();
+        }
+      else
+        {
+          ::close(iSockFd_);
+
+          if(bConnected_ &&  protocol_ == Protocol::PROTOCOL_TCP_SERVER)
+            {
+              ::close(iSessionSockFd_);
+            }
+        }
+
+
+      bOpen_ = false;
     }
-
-  udp_.close();
-
-  bOpen_ = false;
 }
 
 void EMANE::BoundaryMessageManager::sendPacketMessage(const PacketInfo & packetInfo,
@@ -138,15 +172,15 @@ void EMANE::BoundaryMessageManager::sendPacketMessage(const PacketInfo & packetI
   dataMessage.u16Src_ = packetInfo.getSource();
   dataMessage.u16Dst_ = packetInfo.getDestination();
   dataMessage.u8Priority_ = packetInfo.getPriority();
-  dataMessage.u16DataLen_ = packetDataLength;
-  dataMessage.u16CtrlLen_ = controlMessageSerializer.getLength();
+  dataMessage.u32DataLen_ = packetDataLength;
+  dataMessage.u32CtrlLen_ = controlMessageSerializer.getLength();
 
   NetAdapterDataMessageToNet(&dataMessage);
 
   NetAdapterHeader header;
   memset(&header,0,sizeof(header));
   header.u16Id_ = NETADAPTER_DATA_MSG;
-  header.u16Length_ =
+  header.u32Length_ =
     sizeof(header) +
     sizeof(dataMessage) +
     packetDataLength +
@@ -169,16 +203,48 @@ void EMANE::BoundaryMessageManager::sendPacketMessage(const PacketInfo & packetI
                   controlVectorIO.begin(),
                   controlVectorIO.end());
 
-  if((len = udp_.send(&vectorIO[0],
-                      static_cast<int>(vectorIO.size()),
-                      remoteAddress_)) == -1)
+  if(protocol_ == Protocol::PROTOCOL_UDP)
     {
-      LOGGER_STANDARD_LOGGING(*LogServiceSingleton::instance(),
-                              ERROR_LEVEL,"NEM %03d BoundaryMessageManager error "
-                              "on message send (expected:%zu actual:%zd)",
-                              id_,
-                              packetDataLength,
-                              len);
+      if((len = udp_.send(&vectorIO[0],
+                          static_cast<int>(vectorIO.size()),
+                          remoteAddress_)) == -1)
+        {
+          LOGGER_STANDARD_LOGGING(*LogServiceSingleton::instance(),
+                                  ERROR_LEVEL,"NEM %03d BoundaryMessageManager error "
+                                  "on message send (expected:%zu actual:%zd)",
+                                  id_,
+                                  packetDataLength,
+                                  len);
+        }
+    }
+  else
+    {
+      msghdr msg;
+      memset(&msg,0,sizeof(msg));
+      msg.msg_iov = const_cast<iovec *>(&vectorIO[0]);
+      msg.msg_iovlen = vectorIO.size();
+
+      std::lock_guard<std::mutex> m(mutex_);
+
+      if(bConnected_)
+        {
+          if((len = sendmsg(iSessionSockFd_,&msg,0)) == -1)
+            {
+              LOGGER_STANDARD_LOGGING(*LogServiceSingleton::instance(),
+                                      ERROR_LEVEL,"NEM %03d BoundaryMessageManager error "
+                                      "on message send (expected:%zu actual:%zd)",
+                                      id_,
+                                      packetDataLength,
+                                      len);
+            }
+        }
+      else
+        {
+          LOGGER_STANDARD_LOGGING(*LogServiceSingleton::instance(),
+                                  DEBUG_LEVEL,"NEM %03d BoundaryMessageManager "
+                                  "not connected",
+                                  id_);
+        }
     }
 
   std::for_each(msgs.begin(),msgs.end(),[](const ControlMessage * p){delete p;});
@@ -194,14 +260,14 @@ void EMANE::BoundaryMessageManager::sendControlMessage(const ControlMessages & m
   memset(&header,0,sizeof(header));
 
   header.u16Id_ =  NETADAPTER_CTRL_MSG;
-  header.u16Length_ = sizeof(header) + controlMessageSerializer.getLength() + 2;
+  header.u32Length_ = sizeof(header) + controlMessageSerializer.getLength() + 2;
 
   NetAdapterHeaderToNet(&header);
 
   NetAdapterControlMessage controlMessage;
 
   memset(&controlMessage,0,sizeof(NetAdapterControlMessage));
-  controlMessage.u16CtrlLen_ = controlMessageSerializer.getLength();
+  controlMessage.u32CtrlLen_ = controlMessageSerializer.getLength();
 
   NetAdapterControlMessageToNet(&controlMessage);
 
@@ -213,134 +279,127 @@ void EMANE::BoundaryMessageManager::sendControlMessage(const ControlMessages & m
     controlMessageSerializer.getVectorIO();
 
   vectorIO.insert(vectorIO.end(),
-                             controlMessageVectorIO.begin(),
-                             controlMessageVectorIO.end());
+                  controlMessageVectorIO.begin(),
+                  controlMessageVectorIO.end());
 
-  if((len = udp_.send(&vectorIO[0],
-                      static_cast<int>(vectorIO.size()),
-                      remoteAddress_)) == -1)
+  if(protocol_ == Protocol::PROTOCOL_UDP)
     {
-      LOGGER_STANDARD_LOGGING(*LogServiceSingleton::instance(),
-                              ERROR_LEVEL,"NEM %03d BoundaryMessageManager "
-                              "error on control message send (expected:%hu actual:%zu)",
-                               id_,
-                               header.u16Length_,
-                               len);
+      if((len = udp_.send(&vectorIO[0],
+                          static_cast<int>(vectorIO.size()),
+                          remoteAddress_)) == -1)
+        {
+          LOGGER_STANDARD_LOGGING(*LogServiceSingleton::instance(),
+                                  ERROR_LEVEL,"NEM %03d BoundaryMessageManager "
+                                  "error on control message send (expected:%u actual:%zu)",
+                                  id_,
+                                  header.u32Length_,
+                                  len);
+        }
+    }
+  else
+    {
+      msghdr msg;
+      memset(&msg,0,sizeof(msg));
+
+      msg.msg_iov = const_cast<iovec *>(&vectorIO[0]);
+      msg.msg_iovlen = vectorIO.size();
+
+      std::lock_guard<std::mutex> m(mutex_);
+
+      if(bConnected_)
+        {
+          if((len =  sendmsg(iSessionSockFd_,&msg,0)) == -1)
+            {
+              LOGGER_STANDARD_LOGGING(*LogServiceSingleton::instance(),
+                                      ERROR_LEVEL,"NEM %03d BoundaryMessageManager "
+                                      "error on control message send (expected:%u actual:%zu)",
+                                      id_,
+                                      header.u32Length_,
+                                      len);
+            }
+        }
+      else
+        {
+          LOGGER_STANDARD_LOGGING(*LogServiceSingleton::instance(),
+                                  DEBUG_LEVEL,"NEM %03d BoundaryMessageManager "
+                                  "not connected",
+                                  id_);
+        }
     }
 
   std::for_each(msgs.begin(),msgs.end(),[](const ControlMessage * p){delete p;});
 }
 
-void EMANE::BoundaryMessageManager::processNetworkMessage()
+
+void EMANE::BoundaryMessageManager::handleNetworkMessage(void * buf,size_t len)
 {
-  unsigned char buf[65536];
-  ssize_t len = 0;
-  NEMId dstNemId;
+  NEMId dstNemId{};
 
-  LOGGER_STANDARD_LOGGING(*LogServiceSingleton::instance(),
-                          DEBUG_LEVEL,
-                          "NEM %03d BoundaryMessageManager::processNetworkMessage",
-                          id_);
-
-  while(1)
+  if(static_cast<size_t>(len) >= sizeof(NetAdapterHeader))
     {
-      dstNemId = 0;
+      NetAdapterHeader * pHeader = reinterpret_cast<NetAdapterHeader *>(buf);
 
-      memset(&buf,0,sizeof(buf));
+      NetAdapterHeaderToHost(pHeader);
 
-      if((len = udp_.recv(buf,sizeof(buf),0)) > 0)
+      if(static_cast<size_t>(len) == pHeader->u32Length_)
         {
-          LOGGER_VERBOSE_LOGGING(*LogServiceSingleton::instance(),
-                                  DEBUG_LEVEL,
-                                  "NEM %03d BoundaryMessageManager Pkt Rcvd len: %zd",
-                                  id_,len);
+          len -= sizeof(NetAdapterHeader);
 
-          if(static_cast<size_t>(len) >= sizeof(NetAdapterHeader))
+          switch(pHeader->u16Id_)
             {
-              NetAdapterHeader * pHeader = reinterpret_cast<NetAdapterHeader *>(buf);
+            case NETADAPTER_DATA_MSG:
 
-              NetAdapterHeaderToHost(pHeader);
-
-              if(static_cast<size_t>(len) == pHeader->u16Length_)
+              if(static_cast<size_t>(len) >= sizeof(NetAdapterDataMessage))
                 {
-                  len -= sizeof(NetAdapterHeader);
+                  NetAdapterDataMessage * pMsg =  reinterpret_cast<NetAdapterDataMessage *>(pHeader->data_);
 
-                  switch(pHeader->u16Id_)
+                  NetAdapterDataMessageToHost(pMsg);
+
+                  len -= sizeof(NetAdapterDataMessage);
+
+                  if(pMsg->u16Dst_ == htons(NETADAPTER_BROADCAST_ADDRESS))
                     {
-                    case NETADAPTER_DATA_MSG:
+                      dstNemId = NEM_BROADCAST_MAC_ADDRESS;
+                    }
+                  else
+                    {
+                      dstNemId = pMsg->u16Dst_;
+                    }
 
-                      if(static_cast<size_t>(len) >= sizeof(NetAdapterDataMessage))
+                  if(static_cast<size_t>(len) >= pMsg->u32DataLen_)
+                    {
+                      PacketInfo pinfo{pMsg->u16Src_, dstNemId, pMsg->u8Priority_,Clock::now()};
+
+
+                      UpstreamPacket pkt(pinfo,
+                                         pMsg->data_,
+                                         pMsg->u32DataLen_);
+
+                      len -= pMsg->u32DataLen_;
+
+                      ControlMessages controlMessages;
+
+                      if(static_cast<size_t>(len) ==  pMsg->u32CtrlLen_)
                         {
-                          NetAdapterDataMessage * pMsg =  reinterpret_cast<NetAdapterDataMessage *>(pHeader->data_);
+                          const ControlMessages & controlMessages =
+                            ControlMessageSerializer::create(pMsg->data_ + pMsg->u32DataLen_,
+                                                             pMsg->u32CtrlLen_);
 
-                          NetAdapterDataMessageToHost(pMsg);
-
-                          len -= sizeof(NetAdapterDataMessage);
-
-                          if(pMsg->u16Dst_ == htons(NETADAPTER_BROADCAST_ADDRESS))
+                          try
                             {
-                              dstNemId = NEM_BROADCAST_MAC_ADDRESS;
+                              doProcessPacketMessage(pinfo,
+                                                     pMsg->data_,
+                                                     pMsg->u32DataLen_,
+                                                     controlMessages);
                             }
-                          else
+                          catch(...)
                             {
-                              dstNemId = pMsg->u16Dst_;
-                            }
-
-                          if(static_cast<size_t>(len) >= pMsg->u16DataLen_)
-                            {
-                              PacketInfo pinfo{pMsg->u16Src_, dstNemId, pMsg->u8Priority_,Clock::now()};
-
-
-                              UpstreamPacket pkt(pinfo,
-                                                 pMsg->data_,
-                                                 pMsg->u16DataLen_);
-
-                              len -= pMsg->u16DataLen_;
-
-                              ControlMessages controlMessages;
-
-                              if(static_cast<size_t>(len) ==  pMsg->u16CtrlLen_)
-                                {
-                                  const ControlMessages & controlMessages =
-                                    ControlMessageSerializer::create(pMsg->data_ + pMsg->u16DataLen_,
-                                                                     pMsg->u16CtrlLen_);
-
-                                  try
-                                    {
-                                      doProcessPacketMessage(pinfo,
-                                                             pMsg->data_,
-                                                             pMsg->u16DataLen_,
-                                                             controlMessages);
-                                    }
-                                  catch(...)
-                                    {
-                                      // cannot really do too much at this point, so we'll log it
-                                      // good candidate spot to generate and error event as well
-                                      LOGGER_STANDARD_LOGGING(*LogServiceSingleton::instance(),
-                                                              ERROR_LEVEL,
-                                                              "NEM %03d BoundaryMessageManager::processNetworkMessage "
-                                                              "processUpstreamPacket exception caught",
-                                                              id_);
-                                    }
-                                }
-                              else
-                                {
-                                  LOGGER_STANDARD_LOGGING(*LogServiceSingleton::instance(),
-                                                          ERROR_LEVEL,
-                                                          "NEM %03d BoundaryMessageManager::processNetworkMessage "
-                                                          "processUpstreamPacket size too small for control message data",
-                                                          id_);
-
-
-                                }
-
-                            }
-                          else
-                            {
+                              // cannot really do too much at this point, so we'll log it
+                              // good candidate spot to generate and error event as well
                               LOGGER_STANDARD_LOGGING(*LogServiceSingleton::instance(),
                                                       ERROR_LEVEL,
                                                       "NEM %03d BoundaryMessageManager::processNetworkMessage "
-                                                      "processUpstreamPacket size too small for data message",
+                                                      "processUpstreamPacket exception caught",
                                                       id_);
                             }
                         }
@@ -349,86 +408,128 @@ void EMANE::BoundaryMessageManager::processNetworkMessage()
                           LOGGER_STANDARD_LOGGING(*LogServiceSingleton::instance(),
                                                   ERROR_LEVEL,
                                                   "NEM %03d BoundaryMessageManager::processNetworkMessage "
-                                                  "processUpstreamPacket size too small for packet data message",
+                                                  "processUpstreamPacket size too small for control message data",
                                                   id_);
+
+
                         }
 
-                      break;
-
-                    case NETADAPTER_CTRL_MSG:
-
-                      if(static_cast<size_t>(len)  >= sizeof(NetAdapterControlMessage))
-                        {
-                          NetAdapterControlMessage * pMsg =
-                            reinterpret_cast<NetAdapterControlMessage *>(pHeader->data_);
-
-                          NetAdapterControlMessageToHost(pMsg);
-
-                          len -= sizeof(NetAdapterControlMessage);
-
-                          ControlMessages controlMessages;
-
-                          if(static_cast<size_t>(len) ==  pMsg->u16CtrlLen_)
-                            {
-                              const ControlMessages & controlMessages =
-                                ControlMessageSerializer::create(pMsg->data_,
-                                                                 pMsg->u16CtrlLen_);
-
-                              try
-                                {
-                                  doProcessControlMessage(controlMessages);
-                                }
-                              catch(...)
-                                {
-                                  // cannot really do too much at this point, so we'll log it
-                                  // good candidate spot to generate and error event as well
-                                  LOGGER_STANDARD_LOGGING(*LogServiceSingleton::instance(),
-                                                          ERROR_LEVEL,
-                                                          "NEM %03d BoundaryMessageManager::processNetworkMessage "
-                                                          "processDownstreamControl exception caught",
-                                                          id_);
-                                }
-                            }
-                          else
-                            {
-                              LOGGER_STANDARD_LOGGING(*LogServiceSingleton::instance(),
-                                                      ERROR_LEVEL,
-                                                      "NEM %03d BoundaryMessageManager control message size mismatch",
-                                                      id_);
-                            }
-                        }
-
-                      break;
-
-                    default:
+                    }
+                  else
+                    {
                       LOGGER_STANDARD_LOGGING(*LogServiceSingleton::instance(),
                                               ERROR_LEVEL,
-                                              "NEM %03d BoundaryMessageManager Received unknown message type: %d",
-                                              id_,
-                                              pHeader->u16Id_);
-                      break;
+                                              "NEM %03d BoundaryMessageManager::processNetworkMessage "
+                                              "processUpstreamPacket size too small for data message",
+                                              id_);
                     }
                 }
               else
                 {
                   LOGGER_STANDARD_LOGGING(*LogServiceSingleton::instance(),
                                           ERROR_LEVEL,
-                                          "NEM %03d BoundaryMessageManager Message mismatch expected %hd got %zd",
-                                          id_,
-                                          pHeader->u16Length_,
-                                          len);
+                                          "NEM %03d BoundaryMessageManager::processNetworkMessage "
+                                          "processUpstreamPacket size too small for packet data message",
+                                          id_);
                 }
-            }
-          else
-            {
+
+              break;
+
+            case NETADAPTER_CTRL_MSG:
+
+              if(static_cast<size_t>(len)  >= sizeof(NetAdapterControlMessage))
+                {
+                  NetAdapterControlMessage * pMsg =
+                    reinterpret_cast<NetAdapterControlMessage *>(pHeader->data_);
+
+                  NetAdapterControlMessageToHost(pMsg);
+
+                  len -= sizeof(NetAdapterControlMessage);
+
+                  ControlMessages controlMessages;
+
+                  if(static_cast<size_t>(len) == pMsg->u32CtrlLen_)
+                    {
+                      const ControlMessages & controlMessages =
+                        ControlMessageSerializer::create(pMsg->data_,
+                                                         pMsg->u32CtrlLen_);
+
+                      try
+                        {
+                          doProcessControlMessage(controlMessages);
+                        }
+                      catch(...)
+                        {
+                          // cannot really do too much at this point, so we'll log it
+                          // good candidate spot to generate and error event as well
+                          LOGGER_STANDARD_LOGGING(*LogServiceSingleton::instance(),
+                                                  ERROR_LEVEL,
+                                                  "NEM %03d BoundaryMessageManager::processNetworkMessage "
+                                                  "processDownstreamControl exception caught",
+                                                  id_);
+                        }
+                    }
+                  else
+                    {
+                      LOGGER_STANDARD_LOGGING(*LogServiceSingleton::instance(),
+                                              ERROR_LEVEL,
+                                              "NEM %03d BoundaryMessageManager control message size mismatch",
+                                              id_);
+                    }
+                }
+
+              break;
+
+            default:
               LOGGER_STANDARD_LOGGING(*LogServiceSingleton::instance(),
                                       ERROR_LEVEL,
-                                      "NEM %03d BoundaryMessageManager Message Header mismatch expected %zu got %zd",
+                                      "NEM %03d BoundaryMessageManager Received unknown message type: %d",
                                       id_,
-                                      sizeof(NetAdapterHeader),
-                                      len);
+                                      pHeader->u16Id_);
+              break;
             }
+        }
+      else
+        {
+          LOGGER_STANDARD_LOGGING(*LogServiceSingleton::instance(),
+                                  ERROR_LEVEL,
+                                  "NEM %03d BoundaryMessageManager Message mismatch expected %hd got %zd",
+                                  id_,
+                                  pHeader->u32Length_,
+                                  len);
+        }
+    }
+  else
+    {
+      LOGGER_STANDARD_LOGGING(*LogServiceSingleton::instance(),
+                              ERROR_LEVEL,
+                              "NEM %03d BoundaryMessageManager Message Header mismatch expected %zu got %zd",
+                              id_,
+                              sizeof(NetAdapterHeader),
+                              len);
+    }
+}
 
+void EMANE::BoundaryMessageManager::processNetworkMessageUDP()
+{
+  unsigned char buf[65536];
+  ssize_t len = 0;
+
+  LOGGER_STANDARD_LOGGING(*LogServiceSingleton::instance(),
+                          DEBUG_LEVEL,
+                          "NEM %03d BoundaryMessageManager::processNetworkMessage",
+                          id_);
+
+  while(1)
+    {
+      if((len = udp_.recv(buf,sizeof(buf),0)) > 0)
+        {
+          LOGGER_VERBOSE_LOGGING(*LogServiceSingleton::instance(),
+                                 DEBUG_LEVEL,
+                                 "NEM %03d BoundaryMessageManager Pkt Rcvd len: %zd",
+                                 id_,len);
+
+          handleNetworkMessage(buf,len);
         }
       else
         {
@@ -440,5 +541,253 @@ void EMANE::BoundaryMessageManager::processNetworkMessage()
 
           break;
         }
+    }
+}
+
+void EMANE::BoundaryMessageManager::processNetworkMessageTCP()
+{
+  unsigned char buf[1024];
+  std::uint32_t u32MessageSizeBytes{};
+  std::vector<uint8_t> message{};
+  bool bLocalConnected{};
+  bool bLocalOpen{};
+  int iSockFd{-1};
+
+  LOGGER_STANDARD_LOGGING(*LogServiceSingleton::instance(),
+                          DEBUG_LEVEL,
+                          "NEM %03d BoundaryMessageManager::processNetworkMessageTCP",
+                          id_);
+  while(1)
+    {
+      if(!bLocalOpen)
+        {
+          if((iSockFd = socket(localAddress_.getFamily(),
+                               SOCK_STREAM,
+                               0)) == -1)
+            {
+              LOGGER_STANDARD_LOGGING(*LogServiceSingleton::instance(),
+                                      ERROR_LEVEL,
+                                      "NEM %03d BoundaryMessageManager socket open error: %s",
+                                      id_,
+                                      strerror(errno));
+
+              break;
+            }
+
+          int iOption{1};
+
+          if(setsockopt(iSockFd,
+                        SOL_SOCKET,
+                        SO_REUSEADDR,
+                        reinterpret_cast<void*>(&iOption),
+                        sizeof(iOption)) < 0)
+            {
+              LOGGER_STANDARD_LOGGING(*LogServiceSingleton::instance(),
+                                      ERROR_LEVEL,
+                                      "NEM %03d BoundaryMessageManager socket SO_REUSEADDR error: %s",
+                                      id_,
+                                      strerror(errno));
+
+              break;
+            }
+
+          if(::bind(iSockFd,
+                    localAddress_.getSockAddr(),
+                    localAddress_.getAddrLength()) < 0)
+            {
+              LOGGER_STANDARD_LOGGING(*LogServiceSingleton::instance(),
+                                      ERROR_LEVEL,
+                                      "NEM %03d BoundaryMessageManager socket bind error: %s",
+                                      id_,
+                                      strerror(errno));
+              break;
+            }
+
+          if(protocol_ == Protocol::PROTOCOL_TCP_SERVER)
+            {
+              if(listen(iSockFd,1) < 0)
+                {
+                  LOGGER_STANDARD_LOGGING(*LogServiceSingleton::instance(),
+                                          ERROR_LEVEL,
+                                          "NEM %03d BoundaryMessageManager socket listen error: %s",
+                                          id_,
+                                          strerror(errno));
+                  break;
+                }
+            }
+
+          bLocalOpen = true;
+
+          // store socket for proper shutdown on boundry close
+          std::lock_guard<std::mutex> m(mutex_);
+          iSockFd_ = iSockFd;
+        }
+
+      int iConnectionSockFd{};
+
+      while(!bLocalConnected)
+        {
+          if(protocol_ == Protocol::PROTOCOL_TCP_SERVER)
+            {
+              if((iConnectionSockFd = accept(iSockFd_,nullptr,nullptr)) > 0)
+                {
+                  bLocalConnected = true;
+                }
+              else
+                {
+                  if(errno == EINTR)
+                    {
+                      continue;
+                    }
+                  else
+                    {
+                      return;
+                    }
+                }
+            }
+          else if(protocol_ == Protocol::PROTOCOL_TCP_CLIENT)
+            {
+              if(connect(iSockFd_,
+                         remoteAddress_.getSockAddr(),
+                         remoteAddress_.getAddrLength()))
+                {
+                  // wait and try again
+                  sleep(1);
+                }
+              else
+                {
+                  bLocalConnected = true;
+                }
+            }
+        }
+
+      // allow sending methods to transmit
+      mutex_.lock();
+
+      bConnected_ = bLocalConnected;
+
+      if(protocol_ == Protocol::PROTOCOL_TCP_SERVER)
+        {
+          iSessionSockFd_ = iConnectionSockFd;
+        }
+      else if(protocol_ == Protocol::PROTOCOL_TCP_CLIENT)
+        {
+          iSessionSockFd_ = iSockFd_;
+          iConnectionSockFd = iSockFd_;
+        }
+
+      mutex_.unlock();
+
+      LOGGER_STANDARD_LOGGING(*LogServiceSingleton::instance(),
+                              INFO_LEVEL,
+                              "NEM %03d BoundaryMessageManager connected",
+                              id_);
+      while(bLocalConnected)
+        {
+          bool bDoDisconnect{};
+
+          // process the session data
+          if(u32MessageSizeBytes == 0)
+            {
+              ssize_t length{}; // number of bytes received
+
+              // read at most 6 bytes from peer to determine message length
+              length = recv(iConnectionSockFd,buf,6 - message.size(),0);
+
+              if(length > 0)
+                {
+                  // save the contents of the message header
+                  message.insert(message.end(),&buf[0],&buf[length]);
+
+                  // is the entire header present
+                  if(message.size() == 6)
+                    {
+                      u32MessageSizeBytes = ntohl(*reinterpret_cast<std::uint32_t *>(&message[2]));
+
+                      // a message length of 0 is not allowed
+                      if(!u32MessageSizeBytes)
+                        {
+                          LOGGER_STANDARD_LOGGING(*LogServiceSingleton::instance(),
+                                                  ERROR_LEVEL,
+                                                  "NEM %03d BoundaryMessageManager Message Header read error",
+                                                  id_);
+                          bDoDisconnect = true;
+                        }
+                    }
+                }
+              else
+                {
+                  LOGGER_STANDARD_LOGGING(*LogServiceSingleton::instance(),
+                                          ERROR_LEVEL,
+                                          "NEM %03d BoundaryMessageManager Message Header read error",
+                                          id_);
+                  bDoDisconnect = true;
+                }
+            }
+          else
+            {
+              // attempt to read message length remaining or max buffer size
+              ssize_t length{};
+
+              length = recv(iConnectionSockFd,
+                            buf,
+                            u32MessageSizeBytes - message.size() > sizeof(buf) ?
+                            sizeof(buf) : u32MessageSizeBytes - message.size(),
+                            0);
+
+              if(length > 0)
+                {
+                  message.insert(message.end(),&buf[0],&buf[length]);
+
+                  // process message when full message is read
+                  if(message.size() == u32MessageSizeBytes)
+                    {
+                      LOGGER_VERBOSE_LOGGING(*LogServiceSingleton::instance(),
+                                             DEBUG_LEVEL,
+                                             "NEM %03d BoundaryMessageManager Pkt Rcvd len: %zd",
+                                             id_,
+                                             message.size());
+
+                      handleNetworkMessage(&message[0],message.size());
+
+                      message.clear();
+                      u32MessageSizeBytes = 0;
+                    }
+                }
+              else
+                {
+                  LOGGER_STANDARD_LOGGING(*LogServiceSingleton::instance(),
+                                          ERROR_LEVEL,
+                                          "NEM %03d BoundaryMessageManager Message Header read error",
+                                          id_);
+
+                  bDoDisconnect = true;
+                }
+            }
+
+          if(bDoDisconnect)
+            {
+              message.clear();
+              u32MessageSizeBytes = 0;
+              bLocalConnected = false;
+            }
+        }
+
+      std::lock_guard<std::mutex> m(mutex_);
+      bConnected_ = false;
+
+      // iConnectionSockFd == iSocketFd for TCP_CLIENT
+      ::close(iConnectionSockFd);
+
+      if(protocol_ == Protocol::PROTOCOL_TCP_CLIENT)
+        {
+          bLocalOpen = false;
+        }
+
+      LOGGER_STANDARD_LOGGING(*LogServiceSingleton::instance(),
+                              INFO_LEVEL,
+                              "NEM %03d BoundaryMessageManager disconnected",
+                              id_);
+
     }
 }

--- a/src/libemane/boundarymessagemanager.h
+++ b/src/libemane/boundarymessagemanager.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2013,2015-2016 - Adjacent Link LLC, Bridgewater, New
- * Jersey
+ * Copyright (c) 2013,2015-2017 - Adjacent Link LLC, Bridgewater,
+ * New Jersey
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -41,6 +41,7 @@
 #include "emane/utils/vectorio.h"
 #include "datagramsocket.h"
 
+#include <mutex>
 #include <thread>
 
 namespace EMANE
@@ -50,11 +51,19 @@ namespace EMANE
   public:
     virtual ~BoundaryMessageManager();
 
+    enum class Protocol
+      {
+        PROTOCOL_UDP,
+        PROTOCOL_TCP_SERVER,
+        PROTOCOL_TCP_CLIENT,
+      };
+
     /**
      * @throw BoundaryMessageManagerException
      */
     void open(const INETAddr & localAddress,
-              const INETAddr & remoteAddress);
+              const INETAddr & remoteAddress,
+              Protocol protocol);
 
     void close();
 
@@ -86,12 +95,19 @@ namespace EMANE
   private:
     NEMId id_;
     DatagramSocket udp_;
+    Protocol protocol_;
     INETAddr localAddress_;
     INETAddr remoteAddress_;
     std::thread thread_;
     bool bOpen_;
+    int iSockFd_;
+    int iSessionSockFd_;
+    bool bConnected_;
+    std::mutex mutex_;
 
-    void processNetworkMessage();
+    void handleNetworkMessage(void * buf,size_t len);
+    void processNetworkMessageUDP();
+    void processNetworkMessageTCP();
   };
 }
 

--- a/src/libemane/nemimpl.h
+++ b/src/libemane/nemimpl.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2013-2015 - Adjacent Link LLC, Bridgewater, New Jersey
+ * Copyright (c) 2013-2015,2017 - Adjacent Link LLC, Bridgewater,
+ * New Jersey
  * Copyright (c) 2011 - DRS CenGen, LLC, Columbia, Maryland
  * All rights reserved.
  *
@@ -61,8 +62,10 @@ namespace EMANE
        * Constructor
        *
        * @param id NEMid of this NEM
-       * @param pNEMLayerStack pointer to a NEMLayerStack to contain in this NEM
-       *
+       * @param pNEMLayerStack pointer to a NEMLayerStack to contain
+       * in this NEM
+       * @param bExternalTransport Flag inficating use of external
+       * transport
        */
       NEMImpl(NEMId id,
               std::unique_ptr<NEMLayerStack> & pNEMLayerStack,
@@ -100,6 +103,7 @@ namespace EMANE
 
       INETAddr platformEndpointAddr_;
       INETAddr transportEndpointAddr_;
+      NEMNetworkAdapter::Protocol protocol_;
 
       // prevent NEM copies
       NEMImpl(const NEMImpl &) = delete;

--- a/src/libemane/nemmanagerimpl.cc
+++ b/src/libemane/nemmanagerimpl.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2016 - Adjacent Link LLC, Bridgewater, New Jersey
+ * Copyright (c) 2013-2017 - Adjacent Link LLC, Bridgewater, New Jersey
  * Copyright (c) 2011 - DRS CenGen, LLC, Columbia, Maryland
  * All rights reserved.
  *
@@ -87,55 +87,71 @@ void EMANE::Application::NEMManagerImpl::initialize(Registrar & registrar)
                                                   {},
                                                   "Device to associate with the OTA channel multicast endpoint.");
 
+  configRegistrar.registerNumeric<std::uint32_t>("otamanagermtu",
+                                                 ConfigurationProperties::DEFAULT,
+    {0},
+                                                 "OTA channel MTU.");
+
+  configRegistrar.registerNumeric<std::uint16_t>("otamanagerpartcheckthreshold",
+                                                 ConfigurationProperties::DEFAULT,
+                                                 {2},
+                                                 "Defines the rate in seconds a check is performed to see if any OTA packet"
+                                                 " part reassembly efforts should be abandoned.");
+
+  configRegistrar.registerNumeric<std::uint16_t>("otamanagerparttimeoutthreshold",
+                                                 ConfigurationProperties::DEFAULT,
+    {5},
+                                                 "Defines the threshold in seconds to wait for another OTA packet part"
+                                                 " for an existing reassembly effort before abandoning the effort.");
+
   configRegistrar.registerNumeric<std::uint8_t>("otamanagerttl",
                                                 ConfigurationProperties::DEFAULT,
                                                 {1},
                                                 "OTA channel multicast message TTL.");
-
 
   configRegistrar.registerNumeric<bool>("otamanagerloopback",
                                         ConfigurationProperties::DEFAULT,
                                         {false},
                                         "Enable multicast loopback on the OTA channel multicast channel.");
 
-   configRegistrar.registerNumeric<bool>("otamanagerchannelenable",
-                                         ConfigurationProperties::DEFAULT,
-                                         {true},
-                                         "Enable OTA channel multicast communication.");
+  configRegistrar.registerNumeric<bool>("otamanagerchannelenable",
+                                        ConfigurationProperties::DEFAULT,
+                                        {true},
+                                        "Enable OTA channel multicast communication.");
 
 
-   configRegistrar.registerNonNumeric<INETAddr>("controlportendpoint",
-                                                ConfigurationProperties::REQUIRED,
-                                                {INETAddr{"0.0.0.0",47000 }},
-                                                "IPv4 or IPv6 control port endpoint.");
+  configRegistrar.registerNonNumeric<INETAddr>("controlportendpoint",
+                                               ConfigurationProperties::REQUIRED,
+                                               {INETAddr{"0.0.0.0",47000 }},
+                                               "IPv4 or IPv6 control port endpoint.");
 
-   configRegistrar.registerNonNumeric<std::string>("antennaprofilemanifesturi",
-                                                   EMANE::ConfigurationProperties::NONE,
-                                                   {},
-                                                   "Absolute URI of the antenna profile manifest to load."
-                                                   " The antenna profile manifest contains a list of"
-                                                   " antenna profile entries. Each entry contains a unique"
-                                                   " profile identifier, an antenna pattern URI and an"
-                                                   " antenna blockage URI. This parameter is required when"
-                                                   " antennaprofileenable is on or if any other NEM"
-                                                   " participating in the emulation has antennaprofileenable"
-                                                   " set on, even in the case where antennaprofileenable is"
-                                                   " off locally.");
+  configRegistrar.registerNonNumeric<std::string>("antennaprofilemanifesturi",
+                                                  EMANE::ConfigurationProperties::NONE,
+                                                  {},
+                                                  "Absolute URI of the antenna profile manifest to load."
+                                                  " The antenna profile manifest contains a list of"
+                                                  " antenna profile entries. Each entry contains a unique"
+                                                  " profile identifier, an antenna pattern URI and an"
+                                                  " antenna blockage URI. This parameter is required when"
+                                                  " antennaprofileenable is on or if any other NEM"
+                                                  " participating in the emulation has antennaprofileenable"
+                                                  " set on, even in the case where antennaprofileenable is"
+                                                  " off locally.");
 
-   configRegistrar.registerNumeric<std::uint32_t>("stats.ota.maxpacketcountrows",
-                                                  ConfigurationProperties::DEFAULT,
-                                                  {0},
-                                                  "OTA channel max packet count table rows.");
+  configRegistrar.registerNumeric<std::uint32_t>("stats.ota.maxpacketcountrows",
+                                                 ConfigurationProperties::DEFAULT,
+                                                 {0},
+                                                 "OTA channel max packet count table rows.");
 
-   configRegistrar.registerNumeric<std::uint32_t>("stats.ota.maxeventcountrows",
-                                                  ConfigurationProperties::DEFAULT,
-                                                  {0},
-                                                  "OTA channel max event count table rows.");
+  configRegistrar.registerNumeric<std::uint32_t>("stats.ota.maxeventcountrows",
+                                                 ConfigurationProperties::DEFAULT,
+                                                 {0},
+                                                 "OTA channel max event count table rows.");
 
-   configRegistrar.registerNumeric<std::uint32_t>("stats.event.maxeventcountrows",
-                                                  ConfigurationProperties::DEFAULT,
-                                                  {0},
-                                                  "Event channel max event count table rows.");
+  configRegistrar.registerNumeric<std::uint32_t>("stats.event.maxeventcountrows",
+                                                 ConfigurationProperties::DEFAULT,
+                                                 {0},
+                                                 "Event channel max event count table rows.");
 
 }
 
@@ -149,7 +165,8 @@ void EMANE::Application::NEMManagerImpl::configure(const ConfigurationUpdate & u
 
           LOGGER_STANDARD_LOGGING(*LogServiceSingleton::instance(),
                                   INFO_LEVEL,
-                                  "NEMManagerImpl::configure OTA Manager Channel Group: %s",
+                                  "NEMManagerImpl::configure %s: %s",
+                                  item.first.c_str(),
                                   OTAManagerGroupAddr_.str().c_str());
 
         }
@@ -173,6 +190,36 @@ void EMANE::Application::NEMManagerImpl::configure(const ConfigurationUpdate & u
                                   "NEMManagerImpl::configure %s: %hhu",
                                   item.first.c_str(),
                                   u8OTAManagerTTL_);
+        }
+      else if(item.first == "otamanagermtu")
+        {
+          u32OTAManagerMTU_ = item.second[0].asUINT32();
+
+          LOGGER_STANDARD_LOGGING(*LogServiceSingleton::instance(),
+                                  INFO_LEVEL,
+                                  "NEMManagerImpl::configure %s: %u",
+                                  item.first.c_str(),
+                                  u32OTAManagerMTU_);
+        }
+      else if(item.first == "otamanagerpartcheckthreshold")
+        {
+          OTAManagerPartCheckThreshold_= EMANE::Seconds{item.second[0].asUINT16()};
+
+          LOGGER_STANDARD_LOGGING(*LogServiceSingleton::instance(),
+                                  INFO_LEVEL,
+                                  "NEMManagerImpl::configure %s = %lu",
+                                  item.first.c_str(),
+                                  OTAManagerPartCheckThreshold_.count());
+        }
+      else if(item.first == "otamanagerparttimeoutthreshold")
+        {
+          OTAManagerPartTimeoutThreshold_ = EMANE::Seconds{item.second[0].asUINT16()};
+
+          LOGGER_STANDARD_LOGGING(*LogServiceSingleton::instance(),
+                                  INFO_LEVEL,
+                                  "NEMManagerImpl::configure %s = %lu",
+                                  item.first.c_str(),
+                                  OTAManagerPartTimeoutThreshold_.count());
         }
       else if(item.first == "otamanagerloopback")
         {
@@ -313,7 +360,10 @@ void EMANE::Application::NEMManagerImpl::start()
                                                 sOTAManagerGroupDevice_,
                                                 bOTAManagerChannelLoopback_,
                                                 u8OTAManagerTTL_,
-                                                uuid_);
+                                                uuid_,
+                                                u32OTAManagerMTU_,
+                                                OTAManagerPartCheckThreshold_,
+                                                OTAManagerPartTimeoutThreshold_);
         }
       catch(OTAException & exp)
         {

--- a/src/libemane/nemmanagerimpl.h
+++ b/src/libemane/nemmanagerimpl.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2013-2015 - Adjacent Link LLC, Bridgewater, New Jersey
+ * Copyright (c) 2013-2015,2017 - Adjacent Link LLC, Bridgewater,
+ * New Jersey
  * Copyright (c) 2011 - DRS CenGen, LLC, Columbia, Maryland
  * All rights reserved.
  *
@@ -83,8 +84,11 @@ namespace EMANE
       INETAddr OTAManagerGroupAddr_;
       std::string sOTAManagerGroupDevice_;
       std::uint8_t u8OTAManagerTTL_;
+      std::uint32_t u32OTAManagerMTU_;
       bool bOTAManagerChannelLoopback_;
       bool bOTAManagerChannelEnable_;
+      Seconds OTAManagerPartCheckThreshold_;
+      Seconds OTAManagerPartTimeoutThreshold_;
 
       INETAddr eventServiceGroupAddr_;
       std::string sEventServiceDevice_;

--- a/src/libemane/netadaptermessage.h
+++ b/src/libemane/netadaptermessage.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 - Adjacent Link LLC, Bridgewater, New Jersey
+ * Copyright (c) 2016-2017 - Adjacent Link LLC, Bridgewater, New Jersey
  * Copyright (c) 2008-2009 - DRS CenGen, LLC, Columbia, Maryland
  * All rights reserved.
  *
@@ -49,7 +49,7 @@ namespace EMANE
   struct NetAdapterHeader
   {
     std::uint16_t u16Id_;     /**< Event id */
-    std::uint16_t u16Length_; /**< Total message length in bytes */
+    std::uint32_t u32Length_; /**< Total message length in bytes */
     std::uint8_t  data_[0];   /**< Pointer to message payload */
   } __attribute__((packed));
 
@@ -64,7 +64,7 @@ namespace EMANE
   NetAdapterHeader * NetAdapterHeaderToHost(NetAdapterHeader * pMsg)
   {
     pMsg->u16Id_     =  ntohs(pMsg->u16Id_);
-    pMsg->u16Length_ =  ntohs(pMsg->u16Length_);
+    pMsg->u32Length_ =  ntohl(pMsg->u32Length_);
     return pMsg;
   }
 
@@ -79,7 +79,7 @@ namespace EMANE
   NetAdapterHeader * NetAdapterHeaderToNet(NetAdapterHeader * pMsg)
   {
     pMsg->u16Id_     =  htons(pMsg->u16Id_);
-    pMsg->u16Length_ =  htons(pMsg->u16Length_);
+    pMsg->u32Length_ =  htonl(pMsg->u32Length_);
     return pMsg;
   }
 
@@ -92,8 +92,8 @@ namespace EMANE
   {
     std::uint16_t u16Src_;
     std::uint16_t u16Dst_;
-    std::uint16_t u16DataLen_;
-    std::uint16_t u16CtrlLen_;
+    std::uint32_t u32DataLen_;
+    std::uint32_t u32CtrlLen_;
     std::uint8_t  u8Priority_;
     std::uint8_t  data_[0];
   } __attribute__((packed));
@@ -105,7 +105,7 @@ namespace EMANE
    */
   struct NetAdapterControlMessage
   {
-    std::uint16_t u16CtrlLen_;
+    std::uint32_t u32CtrlLen_;
     std::uint8_t data_[0];
   } __attribute__((packed));
 
@@ -113,14 +113,14 @@ namespace EMANE
   inline
   NetAdapterControlMessage * NetAdapterControlMessageToHost(NetAdapterControlMessage * ctrl)
   {
-    ctrl->u16CtrlLen_ = ntohs(ctrl->u16CtrlLen_);
+    ctrl->u32CtrlLen_ = ntohl(ctrl->u32CtrlLen_);
     return ctrl;
   }
 
   inline
   NetAdapterControlMessage *  NetAdapterControlMessageToNet(NetAdapterControlMessage * ctrl)
   {
-    ctrl->u16CtrlLen_ = htons(ctrl->u16CtrlLen_);
+    ctrl->u32CtrlLen_ = htonl(ctrl->u32CtrlLen_);
     return ctrl;
   }
 
@@ -134,8 +134,8 @@ namespace EMANE
   {
     pkt->u16Src_      = ntohs(pkt->u16Src_);
     pkt->u16Dst_      = ntohs(pkt->u16Dst_);
-    pkt->u16DataLen_  = ntohs(pkt->u16DataLen_);
-    pkt->u16CtrlLen_  = ntohs(pkt->u16CtrlLen_);
+    pkt->u32DataLen_  = ntohl(pkt->u32DataLen_);
+    pkt->u32CtrlLen_  = ntohl(pkt->u32CtrlLen_);
 
     return pkt;
   }
@@ -150,8 +150,8 @@ namespace EMANE
   {
     pkt->u16Src_      = htons(pkt->u16Src_);
     pkt->u16Dst_      = htons(pkt->u16Dst_);
-    pkt->u16DataLen_  = htons(pkt->u16DataLen_);
-    pkt->u16CtrlLen_  = htons(pkt->u16CtrlLen_);
+    pkt->u32DataLen_  = htonl(pkt->u32DataLen_);
+    pkt->u32CtrlLen_  = htonl(pkt->u32CtrlLen_);
 
     return pkt;
   }

--- a/src/libemane/otaheader.proto
+++ b/src/libemane/otaheader.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014 - Adjacent Link LLC, Bridgewater, New Jersey
+ * Copyright (c) 2014,2017 - Adjacent Link LLC, Bridgewater, New Jersey
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -36,11 +36,15 @@ option optimize_for = SPEED;
 
 message OTAHeader
 {
+  message PayloadInfo
+  {
+    required uint32 eventLength = 1;
+    required uint32 controlLength = 2;
+    required uint32 dataLength = 3;
+  }
   required uint32 source = 1;
   required uint32 destination = 2;
-  required uint32 eventLength = 3;
-  required uint32 controlLength = 4;
-  required uint32 dataLength = 5;
-  required uint64 sequenceNumber = 6;
-  required bytes  uuid = 7;
+  required uint64 sequence = 3;
+  required bytes uuid = 4;
+  optional PayloadInfo payloadInfo = 5;
 }

--- a/src/libemane/otamanager.cc
+++ b/src/libemane/otamanager.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2016 - Adjacent Link LLC, Bridgewater, New Jersey
+ * Copyright (c) 2013-2017 - Adjacent Link LLC, Bridgewater, New Jersey
  * Copyright (c) 2008-2012 - DRS CenGen, LLC, Columbia, Maryland
  * All rights reserved.
  *
@@ -50,10 +50,65 @@
 #include <algorithm>
 #include <uuid.h>
 
+namespace
+{
+  struct PartInfo
+  {
+    bool bMore_; /**< More parts to follow*/
+    std::uint32_t u32Offset_; /**< Offset of payload */
+    std::uint32_t u32Size_;     /**< Part size */
+  } __attribute__((packed));
+
+  std::vector<uint8_t> bufferFromVectorIO(size_t size,
+                                          size_t & index,
+                                          size_t & offset,
+                                          const EMANE::Utils::VectorIO & vectorIO)
+  {
+    std::vector<uint8_t> buf{};
+
+    size_t targetBytes{size};
+
+    while(targetBytes)
+      {
+        size_t available{vectorIO[index].iov_len - offset};
+
+        if(available)
+          {
+            if(available >= targetBytes)
+              {
+                buf.insert(buf.end(),
+                           &reinterpret_cast<uint8_t *>(vectorIO[index].iov_base)[offset],
+                           &reinterpret_cast<uint8_t *>(vectorIO[index].iov_base)[offset+targetBytes]);
+
+                offset += targetBytes;
+
+                targetBytes = 0;
+              }
+            else
+              {
+                buf.insert(buf.end(),
+                           &reinterpret_cast<uint8_t *>(vectorIO[index].iov_base)[offset],
+                           &reinterpret_cast<uint8_t *>(vectorIO[index].iov_base)[offset] + available);
+
+                targetBytes -= available;
+
+                ++index;
+
+                offset = 0;
+              }
+          }
+      }
+
+    return buf;
+  }
+}
+
 EMANE::OTAManager::OTAManager():
   bOpen_(false),
+  otaMTU_{},
   eventStatisticPublisher_{"OTAChannel"},
-  u64SequenceNumber_{}
+  u64SequenceNumber_{},
+  lastPartCheckTime_{}
 {
   uuid_clear(uuid_);
 }
@@ -195,42 +250,134 @@ void EMANE::OTAManager::sendOTAPacket(NEMId id,
       // total message length with data payload is defined below
       EMANEMessage::OTAHeader otaheader;
 
+      size_t totalSizeBytes = pkt.length() +
+        controlMessageSerializer.getLength() +
+        sEventSerialization.size();
+
       otaheader.set_source(pktInfo.getSource());
       otaheader.set_destination(pktInfo.getDestination());
-      otaheader.set_datalength(pkt.length());
-      otaheader.set_controllength(controlMessageSerializer.getLength());
-      otaheader.set_eventlength(sEventSerialization.size());
-      otaheader.set_sequencenumber(++u64SequenceNumber_);
+      otaheader.set_sequence(++u64SequenceNumber_);
       otaheader.set_uuid(reinterpret_cast<const char *>(uuid_),sizeof(uuid_));
 
-      std::string sOTAHeader{};
+      auto pPayloadInfo = otaheader.mutable_payloadinfo();
 
-      if(otaheader.SerializeToString(&sOTAHeader))
+      pPayloadInfo->set_datalength(pkt.length());
+      pPayloadInfo->set_controllength(controlMessageSerializer.getLength());
+      pPayloadInfo->set_eventlength(sEventSerialization.size());
+
+      // vector hold everything to be transmitted except the OTAHeader
+      Utils::VectorIO stagingVectorIO{};
+      size_t stagingIndex{};
+      size_t stagingOffset{};
+
+      if(!sEventSerialization.empty())
         {
+          stagingVectorIO.push_back({const_cast<char *>(sEventSerialization.c_str()),sEventSerialization.size()});
+        }
+
+      const auto & controlMessageIO = controlMessageSerializer.getVectorIO();
+
+      stagingVectorIO.insert(stagingVectorIO.end(),controlMessageIO.begin(),controlMessageIO.end());
+
+      const auto & packetIO = pkt.getVectorIO();
+
+      stagingVectorIO.insert(stagingVectorIO.end(),packetIO.begin(),packetIO.end());
+
+      ++u64SequenceNumber_;
+
+      size_t sentBytes{};
+      PartInfo partInfo{false,0,0};
+
+      while(sentBytes != totalSizeBytes)
+        {
+          EMANEMessage::OTAHeader otaheader;
+          otaheader.set_source(pktInfo.getSource());
+          otaheader.set_destination(pktInfo.getDestination());
+          otaheader.set_sequence(u64SequenceNumber_);
+          otaheader.set_uuid(reinterpret_cast<const char *>(uuid_),sizeof(uuid_));
+
+          if(sentBytes==0)
+            {
+              auto pPayloadInfo = otaheader.mutable_payloadinfo();
+              pPayloadInfo->set_datalength(pkt.length());
+              pPayloadInfo->set_controllength(controlMessageSerializer.getLength());
+              pPayloadInfo->set_eventlength(sEventSerialization.size());
+            }
+
+          std::string sOTAHeader{};
+
+          if(!otaheader.SerializeToString(&sOTAHeader))
+            {
+              LOGGER_STANDARD_LOGGING(*LogServiceSingleton::instance(),
+                                      ERROR_LEVEL,
+                                      "OTAManager sendOTAPacket unable to serialize OTA header src:%hu dst:%hu",
+                                      pktInfo.getSource(),
+                                      pktInfo.getDestination());
+              break;
+            }
+
+          // total wire size includes 16 bit length prefix framing of header
+          size_t totalWireSize = totalSizeBytes - sentBytes + (sOTAHeader.size() + 2) + sizeof(PartInfo);
+
           std::uint16_t u16HeaderLength = HTONS(sOTAHeader.size());
 
           Utils::VectorIO vectorIO{{reinterpret_cast<char *>(&u16HeaderLength),sizeof(u16HeaderLength)},
-              {const_cast<char *>(sOTAHeader.c_str()),sOTAHeader.size()}};
+              {const_cast<char *>(sOTAHeader.c_str()),sOTAHeader.size()},
+                {reinterpret_cast<char *>(&partInfo),sizeof(partInfo)}};
 
-          if(!sEventSerialization.empty())
+          size_t payloadSize{};
+
+          if(otaMTU_ != 0 and totalWireSize > otaMTU_)
             {
-              vectorIO.push_back({const_cast<char *>(sEventSerialization.c_str()),sEventSerialization.size()});
+              partInfo.bMore_ = true;
+              // size of payload only (event + control + packet data)
+              // adjusted for MTU and overhead (OTAHeader +
+              // PartInfo)
+              payloadSize = otaMTU_ - (sOTAHeader.size() + 2 + sizeof(partInfo));
+              partInfo.u32Size_ = HTONL(payloadSize);
+            }
+          else
+            {
+              partInfo.bMore_ = false;
+              // size of payload only (event + control + packet data)
+              payloadSize = totalSizeBytes - sentBytes;
+              partInfo.u32Size_ = HTONL(payloadSize);
             }
 
-          const auto  & controlMessageIO = controlMessageSerializer.getVectorIO();
+          partInfo.u32Offset_ = HTONL(totalSizeBytes - (totalSizeBytes - sentBytes));
 
-          vectorIO.insert(vectorIO.end(),controlMessageIO.begin(),controlMessageIO.end());
+          sentBytes += payloadSize;
 
-          const auto & packetIO = pkt.getVectorIO();
+          while(payloadSize)
+            {
+              size_t avaiableInEntrySize = stagingVectorIO[stagingIndex].iov_len - stagingOffset;
 
-          vectorIO.insert(vectorIO.end(),packetIO.begin(),packetIO.end());
+              if(avaiableInEntrySize > payloadSize)
+                {
+                  vectorIO.push_back({reinterpret_cast<char *>(stagingVectorIO[stagingIndex].iov_base) + stagingOffset,
+                        payloadSize});
+
+                  stagingOffset += payloadSize;
+                  payloadSize = 0;
+                }
+              else
+                {
+                  vectorIO.push_back({reinterpret_cast<char *>(stagingVectorIO[stagingIndex].iov_base) + stagingOffset,
+                        avaiableInEntrySize});
+
+                  payloadSize -= avaiableInEntrySize;
+                  stagingOffset = 0;
+                  ++stagingIndex;
+                }
+            }
 
           // gather and send
           if(mcast_.send(&vectorIO[0],static_cast<int>(vectorIO.size())) == -1)
             {
               LOGGER_STANDARD_LOGGING(*LogServiceSingleton::instance(),
                                       ERROR_LEVEL,
-                                      "OTAManager sendOTAPacket unable to send ctrl_len:%zu, payload_len:%zu src:%hu dst:%hu reason:%s\n",
+                                      "OTAManager sendOTAPacket unable to send ctrl_len:%zu,"
+                                      " payload_len:%zu src:%hu dst:%hu reason:%s\n",
                                       controlMessageSerializer.getLength(),
                                       pkt.length(),
                                       pktInfo.getSource(),
@@ -240,7 +387,7 @@ void EMANE::OTAManager::sendOTAPacket(NEMId id,
             }
           else
             {
-              otaStatisticPublisher_.update(OTAStatisticPublisher::Type::TYPE_DOWNSTREAM,
+              otaStatisticPublisher_.update(OTAStatisticPublisher::Type::TYPE_DOWNSTREAM_PACKET_SUCCESS,
                                             uuid_,
                                             pktInfo.getSource());
 
@@ -252,14 +399,6 @@ void EMANE::OTAManager::sendOTAPacket(NEMId id,
                                                   std::get<1>(entry));
                 }
             }
-        }
-      else
-        {
-          LOGGER_STANDARD_LOGGING(*LogServiceSingleton::instance(),
-                                  ERROR_LEVEL,
-                                  "OTAManager sendOTAPacket unable to serialize OTA header src:%hu dst:%hu",
-                                  pktInfo.getSource(),
-                                  pktInfo.getDestination());
         }
     }
 
@@ -293,10 +432,15 @@ void EMANE::OTAManager::open(const INETAddr & otaGroupAddress,
                              const std::string & otaManagerDevice,
                              bool bLoopback,
                              int iTTL,
-                             const uuid_t & uuid)
+                             const uuid_t & uuid,
+                             size_t otaMTU,
+                             Seconds partCheckThreshold,
+                             Seconds partTimeoutThreshold)
 {
   otaGroupAddress_ = otaGroupAddress;
-
+  otaMTU_ = otaMTU;
+  partCheckThreshold_ = partCheckThreshold;
+  partTimeoutThreshold_ = partTimeoutThreshold;
   uuid_copy(uuid_,uuid);
 
   try
@@ -363,119 +507,147 @@ void EMANE::OTAManager::processOTAMessage()
 
               EMANEMessage::OTAHeader otaHeader;
 
-              if(static_cast<size_t>(len) >= *pu16OTAHeaderLength &&
+              size_t payloadIndex{2 + *pu16OTAHeaderLength + sizeof(PartInfo)};
+
+              if(static_cast<size_t>(len) >= *pu16OTAHeaderLength + sizeof(PartInfo) &&
                  otaHeader.ParseFromArray(&buf[2], *pu16OTAHeaderLength))
                 {
-                  if(static_cast<size_t>(len) ==
-                     otaHeader.datalength() +
-                     otaHeader.controllength() +
-                     otaHeader.eventlength() +
-                     *pu16OTAHeaderLength)
+                  PartInfo * pPartInfo{reinterpret_cast<PartInfo *>(&buf[2+*pu16OTAHeaderLength])};
+                  pPartInfo->u32Offset_ = NTOHL(pPartInfo->u32Offset_);
+                  pPartInfo->u32Size_ = NTOHL(pPartInfo->u32Size_);
+
+                  uuid_t remoteUUID;
+                  uuid_copy(remoteUUID,reinterpret_cast<const unsigned char *>(otaHeader.uuid().data()));
+
+                  // only process messages that were not sent by this instance
+                  if(uuid_compare(uuid_,remoteUUID))
                     {
-                      std::uint16_t u16EventIndex = 2 + *pu16OTAHeaderLength;
-                      std::uint16_t u16ControlIndex = u16EventIndex + otaHeader.eventlength();
-                      std::uint16_t u16PacketIndex = u16ControlIndex + otaHeader.controllength();
-
-                      uuid_t remoteUUID;
-                      uuid_copy(remoteUUID,reinterpret_cast<const unsigned char *>(otaHeader.uuid().data()));
-
-                      if(uuid_compare(uuid_,remoteUUID))
+                      // verify we have the advertized part length
+                      if(static_cast<size_t>(len) ==
+                         *pu16OTAHeaderLength +
+                         sizeof(PartInfo) +
+                         pPartInfo->u32Size_)
                         {
-                          if(otaHeader.eventlength())
+                          // message contained in a single part
+                          if(!pPartInfo->bMore_  && !pPartInfo->u32Offset_)
                             {
-                              EMANEMessage::Event::Data data;
+                              auto & payloadInfo = otaHeader.payloadinfo();
+                              handleOTAMessage(otaHeader.source(),
+                                               otaHeader.destination(),
+                                               remoteUUID,
+                                               now,
+                                               payloadInfo.eventlength(),
+                                               payloadInfo.controllength(),
+                                               payloadInfo.datalength(),
+                                               {{&buf[payloadIndex],pPartInfo->u32Size_}});
+                            }
+                          else
+                            {
+                              PartKey partKey = PartKey{otaHeader.source(),otaHeader.sequence()};
 
-                              if(data.ParseFromArray(&buf[u16EventIndex],otaHeader.eventlength()))
+                              auto iter = partStore_.find(partKey);
+
+                              if(iter != partStore_.end())
                                 {
-                                  for(const auto & serialization : data.serializations())
-                                    {
-                                      EventServiceSingleton::instance()->processEventMessage(serialization.nemid(),
-                                                                                             serialization.eventid(),
-                                                                                             serialization.data());
+                                  size_t & totalReceivedPartsBytes{std::get<0>(iter->second)};
+                                  size_t & totalEventBytes{std::get<1>(iter->second)};
+                                  size_t & totalControlBytes{std::get<2>(iter->second)};
+                                  size_t & totalDataBytes{std::get<3>(iter->second)};
+                                  auto & parts{std::get<4>(iter->second)};
+                                  auto & lastPartTime{std::get<5>(iter->second)};
 
-                                      eventStatisticPublisher_.update(EventStatisticPublisher::Type::TYPE_RX,
-                                                                      remoteUUID,
-                                                                      serialization.eventid());
+                                  // check to see if first part has been received
+                                  if(otaHeader.has_payloadinfo())
+                                    {
+                                      auto & payloadInfo = otaHeader.payloadinfo();
+                                      totalEventBytes = payloadInfo.eventlength();
+                                      totalControlBytes = payloadInfo.controllength();
+                                      totalDataBytes = payloadInfo.datalength();
+                                    }
+
+                                  // update last part receive time
+                                  lastPartTime = now;
+
+                                  // add this part to parts and update receive count
+                                  totalReceivedPartsBytes +=  pPartInfo->u32Size_;
+
+                                  parts.insert(std::make_pair(static_cast<size_t>(pPartInfo->u32Offset_),
+                                                              std::vector<uint8_t>(&buf[payloadIndex],
+                                                                                   &buf[payloadIndex + pPartInfo->u32Size_])));
+
+                                  // determine if all parts are accounted for
+                                  size_t totalExpectedPartsBytes = totalDataBytes + totalEventBytes + totalControlBytes;
+
+                                  if(totalReceivedPartsBytes  == totalExpectedPartsBytes)
+                                    {
+                                      Utils::VectorIO vectorIO{};
+
+                                      // get the parts sorted by offset and build an iovec
+                                      for(const auto & part : parts)
+                                        {
+                                          vectorIO.push_back({const_cast<uint8_t *>(&part.second[0]),
+                                                part.second.size()});
+                                        }
+
+                                      handleOTAMessage(otaHeader.source(),
+                                                       otaHeader.destination(),
+                                                       remoteUUID,
+                                                       now,
+                                                       totalEventBytes,
+                                                       totalControlBytes,
+                                                       totalDataBytes,
+                                                       vectorIO);
+
+                                      // remove part cache and part time store
+                                      partStore_.erase(iter);
                                     }
                                 }
                               else
                                 {
-                                  LOGGER_STANDARD_LOGGING(*LogServiceSingleton::instance(),
-                                                          ERROR_LEVEL,"OTAManager message events could not be deserialized");
-                                }
-                            }
+                                  PartKey partKey = PartKey{otaHeader.source(),otaHeader.sequence()};
 
-                          // create packet info from the ota data message
-                          PacketInfo pktInfo(otaHeader.source(),
-                                             otaHeader.destination(),
-                                             0,
-                                             now,
-                                             remoteUUID);
+                                  Parts parts{};
 
-                          UpstreamPacket pkt(pktInfo,&buf[u16PacketIndex],otaHeader.datalength());
+                                  parts.insert(std::make_pair(static_cast<size_t>(pPartInfo->u32Offset_),
+                                                              std::vector<uint8_t>(&buf[payloadIndex],
+                                                                                   &buf[payloadIndex + pPartInfo->u32Size_])));
 
-                          Controls::OTATransmitters otaTransmitters;
+                                  std::array<uint8_t,sizeof(uuid_t)> uuid;
+                                  uuid_copy(uuid.data(),remoteUUID);
 
-                          if(otaHeader.controllength())
-                            {
-                              ControlMessages msgs =
-                                ControlMessageSerializer::create(&buf[u16ControlIndex],
-                                                                 otaHeader.controllength());
-
-                              for(ControlMessages::const_iterator iter = msgs.begin(),end = msgs.end();
-                                  iter != end;
-                                  ++iter)
-                                {
-                                  if((*iter)->getId() == Controls::SerializedControlMessage::IDENTIFIER)
+                                  // first part of message
+                                  // check to see if first part has been received
+                                  if(otaHeader.has_payloadinfo())
                                     {
-                                      auto pSerializedControlMessage =
-                                        static_cast<const Controls::SerializedControlMessage *>(*iter);
+                                      auto & payloadInfo = otaHeader.payloadinfo();
 
-                                      if(pSerializedControlMessage->getSerializedId() ==
-                                         Controls::OTATransmitterControlMessage::IDENTIFIER)
-                                        {
-                                          std::unique_ptr<Controls::OTATransmitterControlMessage>
-                                            pOTATransmitterControlMessage(Controls::OTATransmitterControlMessage::
-                                                                          create(pSerializedControlMessage->getSerialization()));
-
-                                          otaTransmitters = pOTATransmitterControlMessage->getOTATransmitters();
-                                        }
-
+                                      partStore_.insert({partKey,{static_cast<size_t>(pPartInfo->u32Size_),
+                                              payloadInfo.eventlength(),
+                                              payloadInfo.controllength(),
+                                              payloadInfo.datalength(),
+                                              parts,
+                                              now,
+                                              uuid}});
                                     }
-
-                                  // delete all control messages
-                                  delete *iter;
+                                  else
+                                    {
+                                      partStore_.insert({partKey,{static_cast<size_t>(pPartInfo->u32Size_),
+                                              0, // event length
+                                              0, // control length
+                                              0, // data length
+                                              parts,
+                                              now,
+                                              uuid}});
+                                    }
                                 }
                             }
-
-                          otaStatisticPublisher_.update(OTAStatisticPublisher::Type::TYPE_UPSTREAM,
-                                                        remoteUUID,
-                                                        pktInfo.getSource());
-
-                          // for each local NEM stack
-                          for(NEMUserMap::const_iterator iter = nemUserMap_.begin(), end = nemUserMap_.end();
-                              iter != end; ++iter)
-                            {
-                              // only send pkt up to NEM(s) NOT in the ATS
-                              if(otaTransmitters.count(iter->first) == 0)
-                                {
-                                  iter->second->processOTAPacket(pkt,ControlMessages());
-                                }
-                            }
-
                         }
-                    }
-                  else
-                    {
-                      LOGGER_STANDARD_LOGGING(*LogServiceSingleton::instance(),
-                                              ERROR_LEVEL,
-                                              "OTAManager Packet received data length incorrect"
-                                              " len: %zd header:%hu data:%u control: %u event: %u ",
-                                              len,
-                                              *pu16OTAHeaderLength,
-                                              otaHeader.datalength(),
-                                              otaHeader.controllength(),
-                                              otaHeader.eventlength());
+                      else
+                        {
+                          LOGGER_STANDARD_LOGGING(*LogServiceSingleton::instance(),
+                                                  ERROR_LEVEL,
+                                                  "OTAManager message part size mismatch");
+                        }
                     }
                 }
               else
@@ -491,6 +663,41 @@ void EMANE::OTAManager::processOTAMessage()
                                       ERROR_LEVEL,
                                       "OTAManager message missing header missing prefix length encoding");
             }
+
+          // check to see if there are part assemblies to abandon
+          if(lastPartCheckTime_ + partCheckThreshold_ <= now)
+            {
+              for(auto iter = partStore_.begin(); iter != partStore_.end();)
+                {
+                  auto & lastPartTime{std::get<5>(iter->second)};
+
+                  if(lastPartTime + partTimeoutThreshold_ <= now)
+                    {
+                      auto & srcNEM = std::get<0>(iter->first);
+                      uuid_t uuid;
+                      uuid_copy(uuid,std::get<6>(iter->second).data());
+
+                      otaStatisticPublisher_.update(OTAStatisticPublisher::Type::TYPE_UPSTREAM_PACKET_DROP_MISSING_PARTS,
+                                                    uuid,
+                                                    srcNEM);
+
+                      LOGGER_STANDARD_LOGGING(*LogServiceSingleton::instance(),
+                                              ERROR_LEVEL,
+                                              "OTAManager missing one or more packet parts src:"
+                                              " %hu sequence: %ju, dropping.",
+                                              srcNEM,
+                                              std::get<1>(iter->first));
+
+                      partStore_.erase(iter++);
+                    }
+                  else
+                    {
+                      ++iter;
+                    }
+                }
+
+              lastPartCheckTime_ = now;
+            }
         }
       else
         {
@@ -499,5 +706,129 @@ void EMANE::OTAManager::processOTAMessage()
                                   "OTAManager Packet Received error");
           break;
         }
+
+    }
+}
+
+
+void  EMANE::OTAManager::handleOTAMessage(NEMId source,
+                                          NEMId destination,
+                                          const uuid_t & remoteUUID,
+                                          const TimePoint & now,
+                                          size_t eventsSize,
+                                          size_t controlsSize,
+                                          size_t dataSize,
+                                          const Utils::VectorIO & vectorIO)
+{
+  size_t index{};
+  size_t offset{};
+
+  if(eventsSize)
+    {
+      std::vector<uint8_t> buf{bufferFromVectorIO(eventsSize,
+                                                  index,
+                                                  offset,
+                                                  vectorIO)};
+      EMANEMessage::Event::Data data;
+
+      if(data.ParseFromArray(&buf[0],eventsSize))
+        {
+          for(const auto & serialization : data.serializations())
+            {
+              EventServiceSingleton::instance()->processEventMessage(serialization.nemid(),
+                                                                     serialization.eventid(),
+                                                                     serialization.data());
+
+              eventStatisticPublisher_.update(EventStatisticPublisher::Type::TYPE_RX,
+                                              remoteUUID,
+                                              serialization.eventid());
+            }
+        }
+      else
+        {
+          LOGGER_STANDARD_LOGGING(*LogServiceSingleton::instance(),
+                                  ERROR_LEVEL,
+                                  "OTAManager message events could not be deserialized");
+        }
+    }
+
+  Controls::OTATransmitters otaTransmitters{};
+
+  if(controlsSize)
+    {
+      std::vector<uint8_t> buf{bufferFromVectorIO(controlsSize,
+                                                  index,
+                                                  offset,
+                                                  vectorIO)};
+
+      ControlMessages msgs =
+        ControlMessageSerializer::create(&buf[0],
+                                         controlsSize);
+
+      for(ControlMessages::const_iterator iter = msgs.begin(),end = msgs.end();
+          iter != end;
+          ++iter)
+        {
+          if((*iter)->getId() == Controls::SerializedControlMessage::IDENTIFIER)
+            {
+              auto pSerializedControlMessage =
+                static_cast<const Controls::SerializedControlMessage *>(*iter);
+
+              if(pSerializedControlMessage->getSerializedId() ==
+                 Controls::OTATransmitterControlMessage::IDENTIFIER)
+                {
+                  std::unique_ptr<Controls::OTATransmitterControlMessage>
+                    pOTATransmitterControlMessage(Controls::OTATransmitterControlMessage::
+                                                  create(pSerializedControlMessage->getSerialization()));
+
+                  otaTransmitters = pOTATransmitterControlMessage->getOTATransmitters();
+                }
+
+            }
+
+          // delete all control messages
+          delete *iter;
+        }
+    }
+
+  // create packet info from the ota data message
+  PacketInfo pktInfo(source,
+                     destination,
+                     0,
+                     now,
+                     remoteUUID);
+
+  Utils::VectorIO packetVectorIO{};
+
+  for(; index < vectorIO.size(); ++index, offset=0)
+    {
+      packetVectorIO.push_back({reinterpret_cast<uint8_t *>(vectorIO[index].iov_base) + offset,
+            vectorIO[index].iov_len - offset});
+    }
+
+  UpstreamPacket pkt(pktInfo,packetVectorIO);
+
+  if(pkt.length() == dataSize)
+    {
+      otaStatisticPublisher_.update(OTAStatisticPublisher::Type::TYPE_UPSTREAM_PACKET_SUCCESS,
+                                    remoteUUID,
+                                    pktInfo.getSource());
+
+      // for each local NEM stack
+      for(NEMUserMap::const_iterator iter = nemUserMap_.begin(), end = nemUserMap_.end();
+          iter != end; ++iter)
+        {
+          // only send pkt up to NEM(s) NOT in the ATS
+          if(otaTransmitters.count(iter->first) == 0)
+            {
+              iter->second->processOTAPacket(pkt,ControlMessages());
+            }
+        }
+    }
+  else
+    {
+      LOGGER_STANDARD_LOGGING(*LogServiceSingleton::instance(),
+                              ERROR_LEVEL,
+                              "OTAManager packet size does not match reported size in OTA header");
     }
 }

--- a/src/libemane/otamanager.h
+++ b/src/libemane/otamanager.h
@@ -78,11 +78,21 @@ namespace EMANE
     /**
      * Open the event server channel
      *
-     * @param otaGroupAddress Multicast group address of event service OTA channel
+     * @param otaGroupAddress Multicast group address of event service
+     * OTA channel
      * @param sDevice Name of the OTA device
-     * @param bLoopback Flag indicating whether to set LOOPBACK socket option
+     * @param bLoopback Flag indicating whether to set LOOPBACK socket
+     * option
      * @param iTTL Mutlicast TTL
      * @param uuid Emulator instance UUID
+     * @param otaMTU MTU to enforce. Set to 0 to disable
+     * fragmentation
+     * @param partCheckThreshold Rate in seconds to check if part
+     * reassembly efforts should be abandoned due to missing
+     * fragments
+     * @param partTimeoutThreshold Threshold in seconds to wait for
+     * another fragment before abandoning a specific packet
+     * reassembly.
      */
     void open(const INETAddr & otaGroupAddress,
               const std::string & sDevice,

--- a/src/libemane/otamanager.h
+++ b/src/libemane/otamanager.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2016 - Adjacent Link LLC, Bridgewater, New Jersey
+ * Copyright (c) 2013-2017 - Adjacent Link LLC, Bridgewater, New Jersey
  * Copyright (c) 2008-2012 - DRS CenGen, LLC, Columbia, Maryland
  * All rights reserved.
  *
@@ -46,7 +46,8 @@
 #include <queue>
 #include <atomic>
 #include <thread>
-
+#include <tuple>
+#include <array>
 #include <uuid.h>
 
 
@@ -87,7 +88,10 @@ namespace EMANE
               const std::string & sDevice,
               bool bLoopback,
               int iTTL,
-              const uuid_t & uuid);
+              const uuid_t & uuid,
+              size_t otaMTU,
+              Seconds partCheckThreshold,
+              Seconds partTimeoutThreshold);
 
     void setStatPacketCountRowLimit(size_t rows);
 
@@ -101,11 +105,43 @@ namespace EMANE
     MulticastSocket mcast_;
     bool bOpen_;
     uuid_t uuid_;
+    size_t otaMTU_;
+    Seconds partCheckThreshold_;
+    Seconds partTimeoutThreshold_;
+
     mutable OTAStatisticPublisher otaStatisticPublisher_;
     mutable EventStatisticPublisher eventStatisticPublisher_;
     mutable std::atomic<std::uint64_t> u64SequenceNumber_;
 
+    using PartKey = std::tuple<NEMId, // source NEM
+                               std::uint64_t>; // sequence number
+
+    using Parts = std::map<size_t, // offset
+                           std::vector<std::uint8_t>>;
+
+    using PartsData = std::tuple<size_t, // total size in map
+                                 size_t, // events size bytes
+                                 size_t, // controls size bytes
+                                 size_t, // data size bytes
+                                 Parts, // parts map
+                                 TimePoint, // last part time
+                                 std::array<uint8_t,sizeof(uuid_t)>>; // emulator uuid instance
+
+    using PartStore = std::map<PartKey,PartsData>;
+    PartStore partStore_;
+    TimePoint lastPartCheckTime_;
+
+
     void processOTAMessage();
+
+    void handleOTAMessage(NEMId source,
+                          NEMId destination,
+                          const uuid_t & remoteUUID,
+                          const TimePoint & now,
+                          size_t eventsSize,
+                          size_t controlsSize,
+                          size_t dataSize,
+                          const Utils::VectorIO & vectorIO);
   };
 
   using OTAManagerSingleton = OTAManager;

--- a/src/libemane/otastatisticpublisher.h
+++ b/src/libemane/otastatisticpublisher.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016 - Adjacent Link LLC, Bridgewater, New Jersey
+ * Copyright (c) 2016-2017 - Adjacent Link LLC, Bridgewater, New Jersey
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -52,12 +52,15 @@ namespace EMANE
     OTAStatisticPublisher();
 
     enum class Type
-    {
-      TYPE_UPSTREAM,
-        TYPE_DOWNSTREAM,
-    };
+      {
+        TYPE_UPSTREAM_PACKET_SUCCESS,
+        TYPE_DOWNSTREAM_PACKET_SUCCESS,
+        TYPE_UPSTREAM_PACKET_DROP_MISSING_PARTS,
+      };
 
-    void update(Type type, const uuid_t & uuid, NEMId nemId);
+    void update(Type type,
+                const uuid_t & uuid,
+                NEMId nemId);
 
     void setRowLimit(size_t rows);
 
@@ -67,10 +70,13 @@ namespace EMANE
     using PacketCountInfo =
       std::map<PacketCountTableKey,
                std::tuple<std::uint64_t, // packets Tx
-                          std::uint64_t>>; // packets Rx
+                          std::uint64_t, // packets Rx
+                          std::uint64_t>>; // packets Rx drop missing
+                                           // parts
 
     StatisticNumeric<std::uint64_t> * pNumOTAChannelDownstreamPackets_;
     StatisticNumeric<std::uint64_t> * pNumOTAChannelUpstreamPackets_;
+    StatisticNumeric<std::uint64_t> * pNumOTAChannelUpstreamPacketsDroppedMissingPart_;
 
     StatisticTable<PacketCountTableKey> * pPacketCountTable_;
 

--- a/src/libemane/transportadapterimpl.h
+++ b/src/libemane/transportadapterimpl.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013-2016 - Adjacent Link LLC, Bridgewater, New Jersey
+ * Copyright (c) 2013-2017 - Adjacent Link LLC, Bridgewater, New Jersey
  * Copyright (c) 2011-2012 - DRS CenGen, LLC, Columbia, Maryland
  * All rights reserved.
  *
@@ -84,6 +84,7 @@ namespace EMANE
       std::unique_ptr<NEMLayer> pTransport_;
       INETAddr transportEndpointAddr_;
       INETAddr platformEndpointAddr_;
+      Protocol protocol_;
 
       void doProcessPacketMessage(const PacketInfo &,
                                   const void * pPacketData,

--- a/src/models/mac/tdma/receivemanager.cc
+++ b/src/models/mac/tdma/receivemanager.cc
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 - Adjacent Link LLC, Bridgewater, New Jersey
+ * Copyright (c) 2015,2017 - Adjacent Link LLC, Bridgewater, New Jersey
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -372,10 +372,10 @@ EMANE::Models::TDMA::ReceiveManager::process(std::uint64_t u64AbsoluteSlotIndex)
                               // missing a fragment - record all bytes received and discontinue assembly
                               size_t totalBytes{message.getData().size()};
 
-                               for(const auto & part : parts)
-                                 {
-                                   totalBytes += part.second.size();
-                                 }
+                              for(const auto & part : parts)
+                                {
+                                  totalBytes += part.second.size();
+                                }
 
                               pPacketStatusPublisher_->inbound(pktInfo.getSource(),
                                                                dst,
@@ -494,5 +494,7 @@ EMANE::Models::TDMA::ReceiveManager::process(std::uint64_t u64AbsoluteSlotIndex)
               ++iter;
             }
         }
+
+      lastFragmentCheckTime_ = now;
     }
 }

--- a/src/models/mac/tdma/receivemanager.h
+++ b/src/models/mac/tdma/receivemanager.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015 - Adjacent Link LLC, Bridgewater, New Jersey
+ * Copyright (c) 2015,2017 - Adjacent Link LLC, Bridgewater, New Jersey
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -130,10 +130,8 @@ namespace EMANE
                                         NEMId, // destination
                                         Priority>;
         using FragmentStore = std::map<FragmentKey,FragmentInfo>;
-        using FragmentTimeStore = std::map<TimePoint,FragmentKey>;
 
         FragmentStore fragmentStore_;
-        FragmentTimeStore fragmentTimeStore_;
         TimePoint lastFragmentCheckTime_;
 
         ReceiveManager(const ReceiveManager &) = delete;


### PR DESCRIPTION
Added OTA fragmentation functionality to support fragmentation and reassembly based on the `otamanagermtu` configuration item (eb4c043).

Added transport modifications to support TCP emulator connections  in order to allow larger than 65535 messages to enter/exit the emulator (3c6c0a7). The `protocol` configuration item was added to the platform nem element and can be either: `udp` or `tcp`. The configuration item  defaults to `udp`, allowing existing configuration for external transports to remain unchanged.

Minor bug fix to TDMA model receive processing (ce0c7f7).