### PR TITLE
Allow custom transport and MAC constructor arguments

### DIFF
--- a/include/emane/application/nembuilder.h
+++ b/include/emane/application/nembuilder.h
@@ -134,12 +134,13 @@ namespace EMANE
        * @throw ConfigureException when an error occurs during
        * configure.
        */
-      template<typename T>
+      template<typename T, typename... Args>
       std::pair<T *, std::unique_ptr<EMANE::NEMLayer>>
       buildMACLayer_T(NEMId id,
                       const std::string & RegistrationName,
                       const ConfigurationUpdateRequest & request,
-                      bool bSkipConfigure = false);
+                      bool bSkipConfigure = false,
+                      Args... args);
 
       /**
        * Builds a Shim layer

--- a/include/emane/application/nembuilder.inl
+++ b/include/emane/application/nembuilder.inl
@@ -30,12 +30,13 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-template<typename T>
+template<typename T, typename... Args>
 std::pair<T *, std::unique_ptr<EMANE::NEMLayer>>
 EMANE::Application::NEMBuilder::buildMACLayer_T(NEMId id,
                                                 const std::string & sRegistrationName,
                                                 const ConfigurationUpdateRequest & request,
-                                                bool bSkipConfigure)
+                                                bool bSkipConfigure,
+                                                Args... args)
 {
   // new platform service
   PlatformServiceProvider * pPlatformService{createPlatformService()};
@@ -44,7 +45,7 @@ EMANE::Application::NEMBuilder::buildMACLayer_T(NEMId id,
   RadioServiceProvider * pRadioService{createRadioService(id)};
 
   // create the radio model
-  T * pMACLayer{new T(id,pPlatformService,pRadioService)};
+  T * pMACLayer{new T(id,pPlatformService,pRadioService, std::forward<Args>(args)...)};
 
   return {pMACLayer,buildMACLayer_i(pMACLayer,
                                     pPlatformService,

--- a/include/emane/application/transportbuilder.h
+++ b/include/emane/application/transportbuilder.h
@@ -163,12 +163,13 @@ namespace EMANE
        * @throw ConfigureException when an error occurs during
        * configure.
        */
-      template<typename T>
+      template<typename T, typename... Args>
       std::pair<T *,std::unique_ptr<TransportAdapter>>
         buildTransportWithAdapter(const NEMId id,
                                   const ConfigurationUpdateRequest& request,
                                   const std::string & sPlatformEndpoint,
-                                  const std::string & sTransportEndpoint) const;
+                                  const std::string & sTransportEndpoint,
+                                  Args... args) const;
 
     private:
       PlatformServiceProvider * newPlatformService() const;

--- a/include/emane/application/transportbuilder.inl
+++ b/include/emane/application/transportbuilder.inl
@@ -31,18 +31,19 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-template<typename T>
+template<typename T, typename... Args>
 std::pair<T *,std::unique_ptr<EMANE::Application::TransportAdapter>>
 EMANE::Application::TransportBuilder::buildTransportWithAdapter(const NEMId id,
                                                                 const ConfigurationUpdateRequest& request,
                                                                 const std::string & sPlatformEndpoint,
-                                                                const std::string & sTransportEndpoint) const
+                                                                const std::string & sTransportEndpoint,
+                                                                Args... args) const
 {
   // new platform service
   EMANE::PlatformServiceProvider * pPlatformService{newPlatformService()};
 
   // create transport
-  T * pInstance{new T{id, pPlatformService}};
+  T * pInstance{new T{id, pPlatformService, std::forward<Args>(args)...}};
 
   auto pTransportAdapater = buildTransportWithAdapter_i(pInstance,
                                                         pPlatformService,


### PR DESCRIPTION
In the current buildTransportWithAdapter and buildMACLayer_T functions
you are limited to only passing in NEMId, PlatformServiceProvider* and RadioServiceProvider* (MAC) as constructor params for a custom transport or MAC layer.  

This change uses a parameter pack to allow an arbitrary number of
arguments to be passed to the transport/MAC constructor. And by using
perfect forwarding there should be no additional cost in copying those
params to the transport instance.

For example, with this change you can do something like this:

```
class MyCoolTransport
{
public:
   MyCoolTransport(
      NEMId id, 
      PlatformServiceProvider* platformService, 
      int customVar1.
      const std::string& customVar2);
};

...

auto ret =
   transportBuilder.buildTransportWithAdapter<MyCoolTransport>(
      id,
      {},  // ConfigurationUpdateRequest
      platformendpoint,
      transportendpoint,
      42,
      "My Cool String");
```

See also this change.   I don't intend to merge this, but used it to test the change to buildMACLayer_T.
https://github.com/bobmourlam/emane-embedded-example/commit/3147d0fed7e1f9e67960a4fdde9059c4fe66fb27?w=1

Signed-off-by: Bob Mourlam bob.mourlam@gmail.com