### PR TITLE
Use a forwarding reference

### DIFF
--- a/include/emane/application/nembuilder.h
+++ b/include/emane/application/nembuilder.h
@@ -140,7 +140,7 @@ namespace EMANE
                       const std::string & RegistrationName,
                       const ConfigurationUpdateRequest & request,
                       bool bSkipConfigure,
-                      Args... args);
+                      Args&&... args);
 
       /**
        * Builds a Shim layer

--- a/include/emane/application/nembuilder.inl
+++ b/include/emane/application/nembuilder.inl
@@ -36,7 +36,7 @@ EMANE::Application::NEMBuilder::buildMACLayer_T(NEMId id,
                                                 const std::string & sRegistrationName,
                                                 const ConfigurationUpdateRequest & request,
                                                 bool bSkipConfigure,
-                                                Args... args)
+                                                Args&&... args)
 {
   // new platform service
   PlatformServiceProvider * pPlatformService{createPlatformService()};

--- a/include/emane/application/transportbuilder.h
+++ b/include/emane/application/transportbuilder.h
@@ -169,7 +169,7 @@ namespace EMANE
                                   const ConfigurationUpdateRequest& request,
                                   const std::string & sPlatformEndpoint,
                                   const std::string & sTransportEndpoint,
-                                  Args... args) const;
+                                  Args&&... args) const;
 
     private:
       PlatformServiceProvider * newPlatformService() const;

--- a/include/emane/application/transportbuilder.inl
+++ b/include/emane/application/transportbuilder.inl
@@ -37,7 +37,7 @@ EMANE::Application::TransportBuilder::buildTransportWithAdapter(const NEMId id,
                                                                 const ConfigurationUpdateRequest& request,
                                                                 const std::string & sPlatformEndpoint,
                                                                 const std::string & sTransportEndpoint,
-                                                                Args... args) const
+                                                                Args&&... args) const
 {
   // new platform service
   EMANE::PlatformServiceProvider * pPlatformService{newPlatformService()};


### PR DESCRIPTION
Previously when I added the Args... parameter pack I was passing by
value, but that doesn't work if one of the constructor params to the
transport/mac layer takes a non-const reference.

I tested this with a changed here.  I don't intend to pull request that
change:
https://github.com/bobmourlam/emane-embedded-example/blob/master/src/radiomodel.h#L54
https://github.com/bobmourlam/emane-embedded-example/blob/master/src/emane-embedded-example.cc#L161