### PR TITLE
Allow setting the TX Antenna bandwidth in the MAC

### DIFF
--- a/src/libemane/frameworkphy.cc
+++ b/src/libemane/frameworkphy.cc
@@ -1566,7 +1566,7 @@ void EMANE::FrameworkPHY::processDownstreamPacket_i(const TimePoint & now,
 
       txAntenna.setFrequencyGroupIndex(0);
 
-      txAntenna.setBandwidthHz(u64BandwidthHz_);
+      txAntenna.setBandwidthHz(u64BandwidthHz);
 
       if(spectralMaskIndex_)
         {


### PR DESCRIPTION
By using the the local variable u64BandwidthHz instead of
u64BandwidthHz_ you can then override the bandwidth in the MAC layer by
using the FrequencyControlMessage.  This was possible in previous
versions of EMANE and I think broken as part of the MIMO change here:

https://github.com/adjacentlink/emane/commit/aab0b4f54ddac7a089df71e80122ced7bafb0271