### PR TITLE
Radio Silence

### DIFF
--- a/src/libemane/frameworkphy.cc
+++ b/src/libemane/frameworkphy.cc
@@ -139,6 +139,7 @@ EMANE::FrameworkPHY::FrameworkPHY(NEMId id,
   timeSyncThreshold_{},
   bNoiseMaxClamp_{},
   dSystemNoiseFiguredB_{},
+  pNumDownstreamPacketsRadioSilenceEnabledDrop_{},
   pTimeSyncThresholdRewrite_{},
   pGainCacheHit_{},
   pGainCacheMiss_{},
@@ -151,7 +152,8 @@ EMANE::FrameworkPHY::FrameworkPHY(NEMId id,
   bStatsObservedPowerTableEnable_{},
   bRxSensitivityPromiscuousModeEnable_{},
   bDopplerShiftEnable_{},
-  spectralMaskIndex_{DEFAULT_SPECTRAL_MASK_INDEX}{}
+  spectralMaskIndex_{DEFAULT_SPECTRAL_MASK_INDEX},
+  bRadioSilenceEnable_{}{}
 
 EMANE::FrameworkPHY::~FrameworkPHY(){}
 
@@ -357,6 +359,13 @@ void EMANE::FrameworkPHY::initialize(Registrar & registrar)
                                                      "Defines the spectral mask index used for all transmissions."
                                                      " Set to 0 to use the emulator default square spectral mask.");
 
+  configRegistrar.registerNumeric<bool>("radiosilenceenable",
+                                        EMANE::ConfigurationProperties::DEFAULT |
+                                        EMANE::ConfigurationProperties::MODIFIABLE,
+                                        {false},
+                                        "Defines whether transmission is allowed. When enabled"
+                                        "over-the-air (downstream) messages will be dropped.");
+
   /** [eventservice-registerevent-snippet] */
   auto & eventRegistrar = registrar.eventRegistrar();
 
@@ -379,6 +388,10 @@ void EMANE::FrameworkPHY::initialize(Registrar & registrar)
   receivePowerTablePublisher_.registerStatistics(statisticRegistrar);
 
   observedPowerTablePublisher_.registerStatistics(statisticRegistrar);
+
+  pNumDownstreamPacketsRadioSilenceEnabledDrop_ =
+    statisticRegistrar.registerNumeric<std::uint64_t>("numDownstreamPacketsRadioSilenceEnabledDrop",
+                                                      StatisticProperties::CLEARABLE);
 
   pTimeSyncThresholdRewrite_ =
     statisticRegistrar.registerNumeric<std::uint64_t>("numTimeSyncThresholdRewrite",
@@ -750,6 +763,19 @@ void EMANE::FrameworkPHY::configure(const ConfigurationUpdate & update)
                                   item.first.c_str(),
                                   spectralMaskIndex_);
         }
+      else if(item.first == "radiosilenceenable")
+        {
+          bRadioSilenceEnable_ = item.second[0].asBool();
+
+          LOGGER_STANDARD_LOGGING(pPlatformService_->logService(),
+                                  INFO_LEVEL,
+                                  "PHYI %03hu FrameworkPHY::%s: %s = %s",
+                                  id_,
+                                  __func__,
+                                  item.first.c_str(),
+                                  bRadioSilenceEnable_ ? "on" : "off");
+        }
+
       else
         {
           if(!item.first.compare(0,FADINGMANAGER_PREFIX.size(),FADINGMANAGER_PREFIX))
@@ -863,6 +889,19 @@ void EMANE::FrameworkPHY::processConfiguration(const ConfigurationUpdate & updat
                                   __func__,
                                   item.first.c_str(),
                                   dTxPowerdBm_);
+        }
+      else if(item.first == "radiosilenceenable")
+        {
+          bRadioSilenceEnable_ = item.second[0].asBool();
+
+          LOGGER_STANDARD_LOGGING(pPlatformService_->logService(),
+                                  INFO_LEVEL,
+                                  "PHYI %03hu FrameworkPHY::%s: %s = %s",
+                                  id_,
+                                  __func__,
+                                  item.first.c_str(),
+                                  bRadioSilenceEnable_ ? "on" : "off");
+
         }
       else
         {
@@ -1182,6 +1221,21 @@ void EMANE::FrameworkPHY::processDownstreamPacket_i(const TimePoint & now,
                          __func__,
                          pktInfo.getSource(),
                          pktInfo.getDestination());
+
+  if (bRadioSilenceEnable_)
+  {
+    ++*pNumDownstreamPacketsRadioSilenceEnabledDrop_;
+
+    LOGGER_VERBOSE_LOGGING(pPlatformService_->logService(),
+                         DEBUG_LEVEL,
+                         "PHYI %03hu FrameworkPHY::%s src %hu, dst %hu"
+                         " drop RadioSilenceEnable is on",
+                         id_,
+                         __func__,
+                         pktInfo.getSource(),
+                         pktInfo.getDestination());
+    return;
+  }
 
   commonLayerStatistics_.processInbound(pkt);
 

--- a/src/libemane/frameworkphy.h
+++ b/src/libemane/frameworkphy.h
@@ -127,6 +127,7 @@ namespace EMANE
     Microseconds timeSyncThreshold_;
     bool bNoiseMaxClamp_;
     double dSystemNoiseFiguredB_;
+    StatisticNumeric<std::uint64_t> * pNumDownstreamPacketsRadioSilenceEnabledDrop_;
     StatisticNumeric<std::uint64_t> * pTimeSyncThresholdRewrite_;
     StatisticNumeric<std::uint64_t> * pGainCacheHit_;
     StatisticNumeric<std::uint64_t> * pGainCacheMiss_;
@@ -149,6 +150,7 @@ namespace EMANE
     bool bRxSensitivityPromiscuousModeEnable_;
     bool bDopplerShiftEnable_;
     SpectralMaskIndex spectralMaskIndex_;
+    bool bRadioSilenceEnable_;
 
     void createDefaultAntennaIfNeeded();
   };


### PR DESCRIPTION
Added radio silence support to the physical layer. 

Radio silence is controlled entirely in the physical layer and its current enable state is not communicated to the radio model. 

Packets dropped when radio silence is enabled are dropped before any other processing.

Radio silence is controlled by the phyisical layer configuration parameter 'radiosilenceenable'.
When 'radiosilenceenable' is set to 'on' all transmissions are dropped.
The parameter is running-state modifiable, and defaults to 'off'.

Added a new statistic numDownstreamPacketsRadioSilenceEnabledDrop which indicates the total packets dropped/not transmitted due to 'radiosilenceenable' being set to 'on'.


Tested with /emane-guide/examples/ieee80211abg-01:
  When not configured on startup (uses default value):
    Behavior unchanged until `emanesh node-1 set config nems phy radiosilenceenable=on` :
      stopped pings.
      `emanesh node-1 get stat nems phy numDownstreamPacketsRadioSilenceEnabledDrop` result increases steadily.
    `emanesh node-1 set config nems phy radiosilenceenable=off` resumes normal behavior :
      pings are received.
      `emanesh node-1 get stat nems phy numDownstreamPacketsRadioSilenceEnabledDrop` result is unchanging.
     
  When configured on startup by:
    `<param name="radiosilenceenable" value="on" />` added to node-1/emane-ieee80211abg-nem.xml
    No pings make it through, and numDownstreamPacketsRadioSilenceEnabledDrop increases steadily.
      Until: `emanesh node-1 set config nems phy radiosilenceenable=on`
        pings are received and numDownstreamPacketsRadioSilenceEnabledDrop result is unchanging.
