### PR TITLE
Add pluggable propagation model support via dlopen

### DIFF
--- a/src/libemane/frameworkphy.cc
+++ b/src/libemane/frameworkphy.cc
@@ -81,6 +81,7 @@
 #include "tworaypropagationmodelalgorithm.h"
 #include "precomputedpropagationmodelalgorithm.h"
 
+#include <dlfcn.h>
 #include <iterator>
 
 namespace
@@ -264,10 +265,11 @@ void EMANE::FrameworkPHY::initialize(Registrar & registrar)
                                                   EMANE::ConfigurationProperties::DEFAULT,
                                                   {"precomputed"},
                                                   "Defines the pathloss mode of operation:"
-                                                  " precomputed, 2ray or freespace.",
+                                                  " precomputed, 2ray or freespace are built-in."
+                                                  " Any other value loads"
+                                                  " libpropagationmodel<name>.so as a plugin.",
                                                   1,
-                                                  1,
-                                                  "^(precomputed|2ray|freespace)$");
+                                                  1);
 
   configRegistrar.registerNumeric<double>("systemnoisefigure",
                                           EMANE::ConfigurationProperties::DEFAULT,
@@ -458,7 +460,6 @@ void EMANE::FrameworkPHY::configure(const ConfigurationUpdate & update)
         {
           std::string sPropagationModel{item.second[0].asString()};
 
-          // regex has already validated values
           if(sPropagationModel == "precomputed")
             {
               pPropagationModelAlgorithm_.reset(new PrecomputedPropagationModelAlgorithm{id_});
@@ -467,9 +468,40 @@ void EMANE::FrameworkPHY::configure(const ConfigurationUpdate & update)
             {
               pPropagationModelAlgorithm_.reset(new TwoRayPropagationModelAlgorithm{id_});
             }
-          else
+          else if(sPropagationModel == "freespace")
             {
               pPropagationModelAlgorithm_.reset(new FreeSpacePropagationModelAlgorithm{id_});
+            }
+          else
+            {
+              // load propagation model plugin: libpropagationmodel<name>.so
+              std::string sLibName{"libpropagationmodel" + sPropagationModel + ".so"};
+
+              void * pHandle = dlopen(sLibName.c_str(), RTLD_NOW);
+
+              if(!pHandle)
+                {
+                  throw makeException<ConfigureException>(
+                    "Failed to load propagation model plugin %s: %s",
+                    sLibName.c_str(),
+                    dlerror());
+                }
+
+              using CreateFunc =
+                PropagationModelAlgorithm * (*)(NEMId, const ConfigurationUpdate &);
+
+              auto createFunc =
+                reinterpret_cast<CreateFunc>(dlsym(pHandle, "createPropagationModel"));
+
+              if(!createFunc)
+                {
+                  dlclose(pHandle);
+                  throw makeException<ConfigureException>(
+                    "Propagation model plugin %s missing createPropagationModel symbol",
+                    sLibName.c_str());
+                }
+
+              pPropagationModelAlgorithm_.reset(createFunc(id_, update));
             }
 
           LOGGER_STANDARD_LOGGING(pPlatformService_->logService(),

--- a/src/libemane/propagationmodelalgorithm.h
+++ b/src/libemane/propagationmodelalgorithm.h
@@ -43,6 +43,8 @@
 
 namespace EMANE
 {
+  class LocationInfo;
+
   class PropagationModelAlgorithm
   {
   public:


### PR DESCRIPTION
## Summary
- Allows external propagation models to be loaded as shared library plugins without modifying libemane
- Any non-builtin `propagationmodel` config value loads `libpropagationmodel<name>.so` via `dlopen`
- Plugin exports a `createPropagationModel(NEMId, ConfigurationUpdate)` factory function returning a `PropagationModelAlgorithm*`
- Built-in models (precomputed, 2ray, freespace) are unchanged and fully backwards compatible

## Changes
- `frameworkphy.cc`: removed regex restriction on propagationmodel config, added dlopen fallback for unknown model names
- `propagationmodelalgorithm.h`: added `LocationInfo` forward declaration so the base class header can be included from standalone plugin compilation units